### PR TITLE
Cohabitation with terminal (with ControlMaster)

### DIFF
--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -337,6 +337,7 @@
 	} else {
 
 		// Disable muxing if requested
+		[taskArguments addObject:@"-S none"];
 		[taskArguments addObject:@"-o ControlMaster=no"];
 	}
 


### PR DESCRIPTION
I have ControlMaster enabled in my ~/.ssh/config since I use it to connect to our servers, the problem is that for some reasons Sequel Pro doesn't like it at all.

If I connect with ssh on my terminal and then try to connect using Sequel pro to a database on the same server Sequel Pro fails to connect, always.
If sequel pro connects first it works.

When the fails there not much informations in the details:

```
Used command:  /usr/bin/ssh -v -N -o ControlMaster=no -o ExitOnForwardFailure=yes -o ConnectTimeout=10 -o NumberOfPasswordPrompts=3 -o TCPKeepAlive=no -o ServerAliveInterval=60 -o ServerAliveCountMax=1 deploy@<IP> -L 54266/127.0.0.1/3306

OpenSSH_6.2p2, OSSLShim 0.9.8r 8 Dec 2011
debug1: Reading configuration data /Users/Schmurfy/.ssh/config
debug1: Reading configuration data /etc/ssh_config
debug1: /etc/ssh_config line 20: Applying options for *
debug1: /etc/ssh_config line 53: Applying options for *
debug1: Requesting forwarding of local forward LOCALHOST:54266 -> 127.0.0.1:3306
debug1: mux_client_request_session: master session id: 5
```

I think `-o ControlMaster=no` is the culprit here, when I need to disable temporarly the ControlMaster (typically to setup port forward) I have found that this works a lot better and is reliable: `-S none` , in theory it should do the same as above but the difference is that the last one actually works...
