### PR TITLE
Disable smart quotes and em dash text replacement

### DIFF
--- a/Source/SPQueryController.m
+++ b/Source/SPQueryController.m
@@ -338,7 +338,7 @@ static SPQueryController *sharedQueryController = nil;
 #pragma mark Other
 
 /**
- * Called whenver the test within the search field changes.
+ * Called whenever the text within the search field changes.
  */
 - (void)controlTextDidChange:(NSNotification *)notification
 {

--- a/Source/SPTextView.m
+++ b/Source/SPTextView.m
@@ -202,8 +202,8 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 	[self _setTextSelectionColor:[NSUnarchiver unarchiveObjectWithData:[prefs dataForKey:SPCustomQueryEditorSelectionColor]] onBackgroundColor:backgroundColor];
 
-	[self setAutomaticDashSubstitutionEnabled:NO];  // prevents ' and " from becoming ‘, ’ and “, ” respectively.
-	[self setAutomaticQuoteSubstitutionEnabled:NO]; // prevents -- from becoming —, the em dash.
+	[self setAutomaticDashSubstitutionEnabled:NO];  // prevents -- from becoming —, the em dash.
+	[self setAutomaticQuoteSubstitutionEnabled:NO]; // prevents ' and " from becoming ‘, ’ and “, ” respectively.
 
 	// Register observers for the when editor background colors preference changes
 	[prefs addObserver:self forKeyPath:SPCustomQueryEditorSelectionColor options:NSKeyValueObservingOptionNew context:NULL];


### PR DESCRIPTION
When the systemwide "Use smart quotes and dashes" option is enabled in Mavericks (System Preferences > Keyboard > Text), the SQL Query editor tries to replace single and double quote characters (', ") with their typographical correct equivalents (‘, ’ and “, ”) as well as a double dash (--) with an Em Dash (—). This may be a wanted setting, but as these replaced characters are not valid string and comment characters, respectively, it breaks the validity of the typed SQL code. 

I've debated whether or not this should be a toggle-able option in the application's editor preferences, but I cannot see a reason that one would ever want to have these characters replaced within SQL. If one did want to enter in the typographical quotes or an em dash as characters within a varchar string (for example), then they could simply use the correct alt-keys (alt+[, alt+], shift+alt+[, and shift+alt+] and alt+-) to insert these characters. In relation to issue #1165, the triple-period ellipses (...) nor the single-character ellipses (…) are valid SQL syntactic elements by themselves, so I see this as a valid reason for overriding the system defaults for these characters, whereas it didn't make sense to override the defaults for characters that don't contribute to SQL syntax.
