### PR TITLE
Fixing the app crash when trying to export and the file already exists (#2010)

### DIFF
--- a/Source/SPExportFileUtilities.m
+++ b/Source/SPExportFileUtilities.m
@@ -269,9 +269,20 @@ SPExportErrorChoice;
 	[NSApp endSheet:exportProgressWindow returnCode:0];
 	[exportProgressWindow orderOut:self];
 	
-	[alert beginSheetModalForWindow:[tableDocumentInstance parentWindow] completionHandler:^(NSModalResponse returnCode) {
-		[self alertDidEnd:alert returnCode:returnCode contextInfo:files];
-	}];
+	// Get the current OS version
+	NSProcessInfo *pInfo = [NSProcessInfo processInfo];
+	NSOperatingSystemVersion version = [pInfo operatingSystemVersion];
+
+	// This will be executed just in OSX prior to 10.9 (Mavericks)
+	if (version.majorVersion == 10 && version.minorVersion < 9) {
+		[alert beginSheetModalForWindow:[tableDocumentInstance parentWindow] modalDelegate:self didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:) contextInfo:files];
+
+	// This is going to be executed in all new versions
+	} else {
+		[alert beginSheetModalForWindow:[tableDocumentInstance parentWindow] completionHandler:^(NSModalResponse returnCode) {
+			[self alertDidEnd:alert returnCode:returnCode contextInfo:files];
+		}];
+	}
 }
 
 /**


### PR DESCRIPTION
Hi guys!

I faced this error too #2010, so I decided to take a look at it.

The reason why this happens is because of Apple made this method deprecated: https://developer.apple.com/Library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSAlert_Class/index.html#//apple_ref/occ/instm/NSAlert/beginSheetModalForWindow:modalDelegate:didEndSelector:contextInfo

Which made the app to fail in Yosemite (It should be working fine in previous versions).
So in order to keep backwards compatibility, I decided to keep the previous code, and add a condition to use the new accepted method just in Mavericks and Yosemite (the only versions that support the method that replaces the deprecated one).

I'm open to any feedback, in case you don't like my approach or if you have a better idea :)

Thanks! 
