### PR TITLE
Fix an issue with ssh -L forwarding (: is the correct separator)

### DIFF
--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -373,10 +373,10 @@
 		[taskArguments addObject:sshHost];
 	}
 	if (useHostFallback) {
-		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld/127.0.0.1/%ld", (long)localPort, (long)remotePort]];
-		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld/%@/%ld", (long)localPortFallback, remoteHost, (long)remotePort]];
+		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld:127.0.0.1:%ld", (long)localPort, (long)remotePort]];
+		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld:%@:%ld", (long)localPortFallback, remoteHost, (long)remotePort]];
 	} else {
-		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld/%@/%ld", (long)localPort, remoteHost, (long)remotePort]];
+		[taskArguments addObject:[NSString stringWithFormat:@"-L %ld:%@:%ld", (long)localPort, remoteHost, (long)remotePort]];
 	}
 
 	[task setArguments:taskArguments];


### PR DESCRIPTION
Hi,

after upgrading openssh to the latest version openssh seems to have finished the support for "-L port/host/port" and only support "-L port:host:port" from now on as it's stated in the man pages. Please take this in mind with the next release.

kind regards
Christoph