### PR TITLE
fallback solution for NSString decode error

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
@@ -239,17 +239,6 @@ static inline NSString * _bitStringWithBytes(const char *bytes, NSUInteger lengt
 	return returnString;
 }
 
-static inline NSString * _convertStringDataSafely(const void *dataBytes, NSUInteger dataLength, NSStringEncoding aStringEncoding)
-{
-    NSString * result = [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding] autorelease];
-
-    if (result == nil) {
-        return [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:NSASCIIStringEncoding] autorelease];
-    }
-
-    return result;
-}
-
 /**
  * Converts stored string data - which may contain nul bytes - to a native
  * Objective-C string, using the current class encoding.
@@ -259,7 +248,7 @@ static inline NSString * _convertStringData(const void *dataBytes, NSUInteger da
 
 	// Fast case - if not using a preview length, or if the data length is shorter, return the requested data.
     if (previewLength == NSNotFound || dataLength <= previewLength) {
-		return _convertStringDataSafely(dataBytes, dataLength, aStringEncoding);
+        return [NSString stringForDataBytes:dataBytes length:dataLength encoding:aStringEncoding];
     }
 
 	NSUInteger i = 0, characterLength = 0, byteLength = previewLength;
@@ -405,7 +394,7 @@ static inline NSString * _convertStringData(const void *dataBytes, NSUInteger da
 
 	// If returning the full string, use a fast path
 	if (byteLength >= dataLength) {
-		return _convertStringDataSafely(dataBytes, dataLength, aStringEncoding);
+		return [NSString stringForDataBytes:dataBytes length:dataLength encoding:aStringEncoding];
 	}
 
 	// Get a string using the calculated details

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
@@ -239,6 +239,17 @@ static inline NSString * _bitStringWithBytes(const char *bytes, NSUInteger lengt
 	return returnString;
 }
 
+static inline NSString * _convertStringDataSafely(const void *dataBytes, NSUInteger dataLength, NSStringEncoding aStringEncoding)
+{
+    NSString * result = [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding] autorelease];
+
+    if (result == nil) {
+        return [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:NSASCIIStringEncoding] autorelease];
+    }
+
+    return result;
+}
+
 /**
  * Converts stored string data - which may contain nul bytes - to a native
  * Objective-C string, using the current class encoding.
@@ -247,9 +258,9 @@ static inline NSString * _convertStringData(const void *dataBytes, NSUInteger da
 {
 
 	// Fast case - if not using a preview length, or if the data length is shorter, return the requested data.
-	if (previewLength == NSNotFound || dataLength <= previewLength) {
-		return [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding] autorelease];
-	}
+    if (previewLength == NSNotFound || dataLength <= previewLength) {
+		return _convertStringDataSafely(dataBytes, dataLength, aStringEncoding);
+    }
 
 	NSUInteger i = 0, characterLength = 0, byteLength = previewLength;
 	uint16_t continuationStart, continuationEnd;
@@ -394,7 +405,7 @@ static inline NSString * _convertStringData(const void *dataBytes, NSUInteger da
 
 	// If returning the full string, use a fast path
 	if (byteLength >= dataLength) {
-		return [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding] autorelease];
+		return _convertStringDataSafely(dataBytes, dataLength, aStringEncoding);
 	}
 
 	// Get a string using the calculated details

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.h
@@ -33,5 +33,6 @@
 
 - (NSString *)mySQLBacktickQuotedString;
 - (NSString *)mySQLTickQuotedString;
++ (NSString *)stringForDataBytes:(const void *)dataBytes length:(NSUInteger)dataLength encoding:(NSStringEncoding)aStringEncoding;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.m
@@ -52,4 +52,18 @@
 	return [NSString stringWithFormat: @"'%@'", [self stringByReplacingOccurrencesOfString:@"'" withString:@"''"]];
 }
 
+/**
+ * Returns the string for the bytes according to the encoding, decode in ASCII if failed
+ */
++ (NSString *) stringForDataBytes:(const void *)dataBytes length:(NSUInteger)dataLength encoding:(NSStringEncoding)aStringEncoding
+{
+    NSString * string = [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding] autorelease];
+    
+    if (string == nil) {
+        return [[[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:NSASCIIStringEncoding] autorelease];
+    }
+    
+    return string;
+}
+
 @end


### PR DESCRIPTION
as the issue reported in #1207, when decode of the create table syntax failed due to data messed up in server side, NSString initWithBytes will return nil. work around by decode in ascii mode will solve this problem.