### PR TITLE
add check for own SSH version in /usr/local/bin/

### DIFF
--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -309,8 +309,18 @@
 
 	// Set up the NSTask
 	task = [[NSTask alloc] init];
-	[task setLaunchPath: @"/usr/bin/ssh"];
-
+	
+	//check if "/usr/local/bin/ssh" exists
+	NSFileManager *fileManager = [NSFileManager defaultManager];
+	
+	if ([fileManager fileExistsAtPath: @"/usr/local/bin/ssh"]){
+		[task setLaunchPath: @"/usr/local/bin/ssh"];
+	}else{
+		// Use default ssh
+		[task setLaunchPath: @"/usr/bin/ssh"];
+	}
+	[fileManager release];
+	
 	// Prepare to set up the arguments for the task
 	taskArguments = [[NSMutableArray alloc] init];
 


### PR DESCRIPTION
I added a check for a custom SSH version at /usr/local/bin/

No integration in the GUI but in case a custom SSH version exists, the user probably want to use it.
See also this request: https://github.com/sequelpro/sequelpro/issues/2083

Maybe I or somebody else will iterate on this.