### PR TITLE
Add an Applications shortcut

### DIFF
--- a/Scripts/package-application.sh
+++ b/Scripts/package-application.sh
@@ -66,6 +66,7 @@ mkdir "${DISTTEMP}"
 
 # Copy in the required distribution files
 cp -R "${BUILT_PRODUCTS_DIR}/${TARGET_NAME}${WRAPPER_SUFFIX}" "${DMG_BUILD_PATH}/disttemp"
+ln -s /Applications "${DMG_BUILD_PATH}/disttemp"
 
 # Create a disk image
 hdiutil create -srcfolder "${DISTTEMP}" -volname "$DMG_VOLUME_NAME" -fs HFS+ -fsargs '-c c=64,a=16,e=16' -format UDRW "${DMG_BUILD_PATH}/${DMG_NAME}.temp.dmg" > /dev/null


### PR DESCRIPTION
To make installing SequelPro easier, a link to /Applications should be present in the DMG. This makes it easier for users to install the application.

I've never done any DMG packaging before (or coding with XCode) but playing with the build scripts, I've tested this and it seems to work correctly.