### PR TITLE
Support ClearText plugin

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -48,6 +48,7 @@
 
 	// SSL connection details
 	BOOL useSSL;
+    NSInteger enableClearTextPlugin;
 	NSString *sslKeyFilePath;
 	NSString *sslCertificatePath;
 	NSString *sslCACertificatePath;
@@ -143,6 +144,7 @@
 @property (readwrite, retain) NSString *socketPath;
 
 @property (readwrite, assign) BOOL useSSL;
+@property (readwrite, assign) NSInteger enableClearTextPlugin;
 @property (readwrite, retain) NSString *sslKeyFilePath;
 @property (readwrite, retain) NSString *sslCertificatePath;
 @property (readwrite, retain) NSString *sslCACertificatePath;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -62,6 +62,7 @@ const char *SPMySQLSSLPermissibleCiphers = "DHE-RSA-AES256-SHA:AES256-SHA:DHE-RS
 @synthesize useSocket;
 @synthesize socketPath;
 @synthesize useSSL;
+@synthesize enableClearTextPlugin;
 @synthesize sslKeyFilePath;
 @synthesize sslCertificatePath;
 @synthesize sslCACertificatePath;
@@ -620,6 +621,11 @@ static uint64_t _elapsedMicroSecondsSinceAbsoluteTime(uint64_t comparisonTime)
 			theSSLCiphers = [sslCipherList UTF8String];
 		}
 
+        //Enable the ClearText plugin if selected by the user
+        if (enableClearTextPlugin) {
+            mysql_options(theConnection, MYSQL_ENABLE_CLEARTEXT_PLUGIN, &enableClearTextPlugin);
+        }
+        
 		mysql_ssl_set(theConnection, theSSLKeyFilePath, theSSLCertificatePath, theCACertificatePath, NULL, theSSLCiphers);
 	}
 

--- a/Interfaces/English.lproj/ConnectionView.xib
+++ b/Interfaces/English.lproj/ConnectionView.xib
@@ -1,9119 +1,2664 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">13F34</string>
-		<string key="IBDocument.InterfaceBuilderVersion">6751</string>
-		<string key="IBDocument.AppKitVersion">1265.21</string>
-		<string key="IBDocument.HIToolboxVersion">698.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">6751</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSImageCell</string>
-			<string>NSImageView</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSPopUpButton</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSProgressIndicator</string>
-			<string>NSScrollView</string>
-			<string>NSScroller</string>
-			<string>NSSplitView</string>
-			<string>NSTabView</string>
-			<string>NSTabViewItem</string>
-			<string>NSTableColumn</string>
-			<string>NSTableView</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSTextView</string>
-			<string>NSUserDefaultsController</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="584594810">
-			<object class="NSCustomObject" id="545410097">
-				<string key="NSClassName">SPConnectionController</string>
-			</object>
-			<object class="NSCustomObject" id="547391009">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="292263310">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSCustomView" id="733821228">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSSplitView" id="616749187">
-						<reference key="NSNextResponder" ref="733821228"/>
-						<int key="NSvFlags">274</int>
-						<array class="NSMutableArray" key="NSSubviews">
-							<object class="NSView" id="551584428">
-								<reference key="NSNextResponder" ref="616749187"/>
-								<int key="NSvFlags">272</int>
-								<array class="NSMutableArray" key="NSSubviews">
-									<object class="NSImageView" id="589005585">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">290</int>
-										<set class="NSMutableSet" key="NSDragTypes">
-											<string>Apple PDF pasteboard type</string>
-											<string>Apple PICT pasteboard type</string>
-											<string>Apple PNG pasteboard type</string>
-											<string>NSFilenamesPboardType</string>
-											<string>NeXT Encapsulated PostScript v1.2 pasteboard type</string>
-											<string>NeXT TIFF v4.0 pasteboard type</string>
-										</set>
-										<string key="NSFrame">{{0, 1}, {200, 22}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="29465158"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSImageCell" key="NSCell" id="147458525">
-											<int key="NSCellFlags">134217728</int>
-											<int key="NSCellFlags2">33554432</int>
-											<object class="NSCustomResource" key="NSContents">
-												<string key="NSClassName">NSImage</string>
-												<string key="NSResourceName">button_bar_spacer</string>
-											</object>
-											<int key="NSAlign">0</int>
-											<int key="NSScale">1</int>
-											<int key="NSStyle">0</int>
-											<bool key="NSAnimates">NO</bool>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-										<bool key="NSEditable">YES</bool>
-									</object>
-									<object class="NSButton" id="973361787">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">292</int>
-										<string key="NSFrame">{{61, -1}, {32, 25}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="250765522"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSButtonCell" key="NSCell" id="953363291">
-											<int key="NSCellFlags">67108864</int>
-											<int key="NSCellFlags2">134217728</int>
-											<string key="NSContents"/>
-											<object class="NSFont" key="NSSupport" id="807120225">
-												<bool key="IBIsSystemFont">YES</bool>
-												<double key="NSSize">13</double>
-												<int key="NSfFlags">1044</int>
-											</object>
-											<reference key="NSControlView" ref="973361787"/>
-											<int key="NSButtonFlags">-2041823232</int>
-											<int key="NSButtonFlags2">35</int>
-											<object class="NSCustomResource" key="NSNormalImage">
-												<string key="NSClassName">NSImage</string>
-												<string key="NSResourceName">button_add</string>
-											</object>
-											<string key="NSAlternateContents"/>
-											<string key="NSKeyEquivalent"/>
-											<int key="NSPeriodicDelay">400</int>
-											<int key="NSPeriodicInterval">75</int>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									</object>
-									<object class="NSButton" id="29465158">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">292</int>
-										<string key="NSFrame">{{30, -1}, {32, 25}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="973361787"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSButtonCell" key="NSCell" id="340161940">
-											<int key="NSCellFlags">67108864</int>
-											<int key="NSCellFlags2">134217728</int>
-											<string key="NSContents"/>
-											<reference key="NSSupport" ref="807120225"/>
-											<reference key="NSControlView" ref="29465158"/>
-											<int key="NSButtonFlags">-2041823232</int>
-											<int key="NSButtonFlags2">35</int>
-											<object class="NSCustomResource" key="NSNormalImage">
-												<string key="NSClassName">NSImage</string>
-												<string key="NSResourceName">button_add_folder</string>
-											</object>
-											<string key="NSAlternateContents"/>
-											<string key="NSKeyEquivalent"/>
-											<int key="NSPeriodicDelay">400</int>
-											<int key="NSPeriodicInterval">75</int>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									</object>
-									<object class="NSPopUpButton" id="735633081">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">292</int>
-										<string key="NSFrame">{{-2, 0}, {36, 23}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="589005585"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSPopUpButtonCell" key="NSCell" id="970960222">
-											<int key="NSCellFlags">67108928</int>
-											<int key="NSCellFlags2">134219776</int>
-											<reference key="NSSupport" ref="807120225"/>
-											<reference key="NSControlView" ref="735633081"/>
-											<int key="NSButtonFlags">-2044051456</int>
-											<int key="NSButtonFlags2">2</int>
-											<string key="NSAlternateContents"/>
-											<string key="NSKeyEquivalent"/>
-											<int key="NSPeriodicDelay">400</int>
-											<int key="NSPeriodicInterval">75</int>
-											<object class="NSMenuItem" key="NSMenuItem" id="797961582">
-												<reference key="NSMenu" ref="167853330"/>
-												<bool key="NSIsHidden">YES</bool>
-												<string key="NSTitle"/>
-												<string key="NSKeyEquiv"/>
-												<int key="NSKeyEquivModMask">1048576</int>
-												<int key="NSMnemonicLoc">2147483647</int>
-												<int key="NSState">1</int>
-												<object class="NSCustomResource" key="NSImage">
-													<string key="NSClassName">NSImage</string>
-													<string key="NSResourceName">button_action</string>
-												</object>
-												<object class="NSCustomResource" key="NSOnImage" id="955092474">
-													<string key="NSClassName">NSImage</string>
-													<string key="NSResourceName">NSMenuCheckmark</string>
-												</object>
-												<object class="NSCustomResource" key="NSMixedImage" id="913188683">
-													<string key="NSClassName">NSImage</string>
-													<string key="NSResourceName">NSMenuMixedState</string>
-												</object>
-												<string key="NSAction">_popUpItemAction:</string>
-												<reference key="NSTarget" ref="970960222"/>
-											</object>
-											<bool key="NSMenuItemRespectAlignment">YES</bool>
-											<object class="NSMenu" key="NSMenu" id="167853330">
-												<string key="NSTitle">OtherViews</string>
-												<array class="NSMutableArray" key="NSMenuItems">
-													<reference ref="797961582"/>
-													<object class="NSMenuItem" id="755096979">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Rename</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="645814925">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Remove</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="612600535">
-														<reference key="NSMenu" ref="167853330"/>
-														<bool key="NSIsDisabled">YES</bool>
-														<bool key="NSIsSeparator">YES</bool>
-														<string key="NSTitle"/>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="78866147">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Duplicate</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="1068847855">
-														<reference key="NSMenu" ref="167853330"/>
-														<bool key="NSIsDisabled">YES</bool>
-														<bool key="NSIsSeparator">YES</bool>
-														<string key="NSTitle"/>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="217054518">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Import...</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="567127977">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Export...</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="214273320">
-														<reference key="NSMenu" ref="167853330"/>
-														<bool key="NSIsDisabled">YES</bool>
-														<bool key="NSIsSeparator">YES</bool>
-														<string key="NSTitle"/>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="505774202">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Make Default</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-													</object>
-													<object class="NSMenuItem" id="788191870">
-														<reference key="NSMenu" ref="167853330"/>
-														<string key="NSTitle">Sort By</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSKeyEquivModMask">1048576</int>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="955092474"/>
-														<reference key="NSMixedImage" ref="913188683"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="970960222"/>
-														<object class="NSMenu" key="NSSubmenu" id="642202204">
-															<string key="NSTitle">Sort By</string>
-															<array class="NSMutableArray" key="NSMenuItems">
-																<object class="NSMenuItem" id="233015422">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<string key="NSTitle">Name</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-																<object class="NSMenuItem" id="703530048">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<string key="NSTitle">Host</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-																<object class="NSMenuItem" id="914367302">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<string key="NSTitle">Type</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-																<object class="NSMenuItem" id="660097916">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<string key="NSTitle">Color</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-																<object class="NSMenuItem" id="975459050">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<bool key="NSIsSeparator">YES</bool>
-																	<string key="NSTitle"/>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-																<object class="NSMenuItem" id="216636539">
-																	<reference key="NSMenu" ref="642202204"/>
-																	<string key="NSTitle">Reverse Sort Order</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="955092474"/>
-																	<reference key="NSMixedImage" ref="913188683"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="970960222"/>
-																</object>
-															</array>
-														</object>
-													</object>
-												</array>
-												<reference key="NSMenuFont" ref="807120225"/>
-											</object>
-											<int key="NSSelectedIndex">10</int>
-											<bool key="NSPullDown">YES</bool>
-											<int key="NSPreferredEdge">1</int>
-											<bool key="NSUsesItemFromMenu">YES</bool>
-											<bool key="NSAltersState">YES</bool>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									</object>
-									<object class="NSImageView" id="250765522">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">289</int>
-										<set class="NSMutableSet" key="NSDragTypes">
-											<string>Apple PDF pasteboard type</string>
-											<string>Apple PICT pasteboard type</string>
-											<string>Apple PNG pasteboard type</string>
-											<string>NSFilenamesPboardType</string>
-											<string>NeXT Encapsulated PostScript v1.2 pasteboard type</string>
-											<string>NeXT TIFF v4.0 pasteboard type</string>
-										</set>
-										<string key="NSFrame">{{185, 1}, {15, 22}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="563806501"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSImageCell" key="NSCell" id="875077014">
-											<int key="NSCellFlags">134217728</int>
-											<int key="NSCellFlags2">33554432</int>
-											<object class="NSCustomResource" key="NSContents">
-												<string key="NSClassName">NSImage</string>
-												<string key="NSResourceName">button_bar_handle</string>
-											</object>
-											<int key="NSAlign">0</int>
-											<int key="NSScale">1</int>
-											<int key="NSStyle">0</int>
-											<bool key="NSAnimates">NO</bool>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-										<bool key="NSEditable">YES</bool>
-									</object>
-									<object class="NSScrollView" id="524598165">
-										<reference key="NSNextResponder" ref="551584428"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSClipView" id="233523429">
-												<reference key="NSNextResponder" ref="524598165"/>
-												<int key="NSvFlags">2322</int>
-												<array class="NSMutableArray" key="NSSubviews">
-													<object class="NSTableView" id="1012579052">
-														<reference key="NSNextResponder" ref="233523429"/>
-														<int key="NSvFlags">4352</int>
-														<string key="NSFrameSize">{200, 489}</string>
-														<reference key="NSSuperview" ref="233523429"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="533108700"/>
-														<bool key="NSEnabled">YES</bool>
-														<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-														<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-														<object class="_NSCornerView" key="NSCornerView">
-															<nil key="NSNextResponder"/>
-															<int key="NSvFlags">-2147483392</int>
-															<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
-														</object>
-														<array class="NSMutableArray" key="NSTableColumns">
-															<object class="NSTableColumn" id="131458815">
-																<double key="NSWidth">197</double>
-																<double key="NSMinWidth">40</double>
-																<double key="NSMaxWidth">1000</double>
-																<object class="NSTableHeaderCell" key="NSHeaderCell">
-																	<int key="NSCellFlags">75497536</int>
-																	<int key="NSCellFlags2">2048</int>
-																	<string key="NSContents">Favorites</string>
-																	<object class="NSFont" key="NSSupport" id="26">
-																		<bool key="IBIsSystemFont">YES</bool>
-																		<double key="NSSize">11</double>
-																		<int key="NSfFlags">3100</int>
-																	</object>
-																	<object class="NSColor" key="NSBackgroundColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																	</object>
-																	<object class="NSColor" key="NSTextColor">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">headerTextColor</string>
-																		<object class="NSColor" key="NSColor" id="643097066">
-																			<int key="NSColorSpace">3</int>
-																			<bytes key="NSWhite">MAA</bytes>
-																		</object>
-																	</object>
-																</object>
-																<object class="NSTextFieldCell" key="NSDataCell" id="93569184">
-																	<int key="NSCellFlags">337641537</int>
-																	<int key="NSCellFlags2">137216</int>
-																	<string key="NSContents">Text Cell</string>
-																	<reference key="NSSupport" ref="26"/>
-																	<reference key="NSControlView" ref="1012579052"/>
-																	<object class="NSColor" key="NSBackgroundColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MQA</bytes>
-																		<object class="NSColorSpace" key="NSCustomColorSpace" id="886601921">
-																			<int key="NSID">2</int>
-																		</object>
-																	</object>
-																	<object class="NSColor" key="NSTextColor" id="434026568">
-																		<int key="NSColorSpace">6</int>
-																		<string key="NSCatalogName">System</string>
-																		<string key="NSColorName">controlTextColor</string>
-																		<reference key="NSColor" ref="643097066"/>
-																	</object>
-																</object>
-																<int key="NSResizingMask">1</int>
-																<bool key="NSIsResizeable">YES</bool>
-																<bool key="NSIsEditable">YES</bool>
-																<reference key="NSTableView" ref="1012579052"/>
-															</object>
-														</array>
-														<double key="NSIntercellSpacingWidth">3</double>
-														<double key="NSIntercellSpacingHeight">2</double>
-														<object class="NSColor" key="NSBackgroundColor">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">_sourceListBackgroundColor</string>
-															<object class="NSColor" key="NSColor">
-																<int key="NSColorSpace">6</int>
-																<string key="NSCatalogName">System</string>
-																<string key="NSColorName">alternateSelectedControlColor</string>
-																<object class="NSColor" key="NSColor" id="981160636">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MCAwIDEAA</bytes>
-																</object>
-															</object>
-														</object>
-														<object class="NSColor" key="NSGridColor">
-															<int key="NSColorSpace">6</int>
-															<string key="NSCatalogName">System</string>
-															<string key="NSColorName">gridColor</string>
-															<object class="NSColor" key="NSColor">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MC41AA</bytes>
-															</object>
-														</object>
-														<double key="NSRowHeight">17</double>
-														<int key="NSTvFlags">507510784</int>
-														<reference key="NSDelegate"/>
-														<reference key="NSDataSource"/>
-														<int key="NSColumnAutoresizingStyle">5</int>
-														<int key="NSDraggingSourceMaskForLocal">15</int>
-														<int key="NSDraggingSourceMaskForNonLocal">0</int>
-														<bool key="NSAllowsTypeSelect">YES</bool>
-														<int key="NSTableViewSelectionHighlightStyle">1</int>
-														<int key="NSTableViewDraggingDestinationStyle">1</int>
-														<int key="NSTableViewGroupRowStyle">1</int>
-													</object>
-												</array>
-												<string key="NSFrameSize">{200, 489}</string>
-												<reference key="NSSuperview" ref="524598165"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="1012579052"/>
-												<reference key="NSDocView" ref="1012579052"/>
-												<object class="NSColor" key="NSBGColor">
-													<int key="NSColorSpace">3</int>
-													<bytes key="NSWhite">MC44ODMwNjQ1MDg0AA</bytes>
-												</object>
-												<int key="NScvFlags">4</int>
-											</object>
-											<object class="NSScroller" id="533108700">
-												<reference key="NSNextResponder" ref="524598165"/>
-												<int key="NSvFlags">-2147483392</int>
-												<string key="NSFrame">{{229, 1}, {15, 524}}</string>
-												<reference key="NSSuperview" ref="524598165"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="802793151"/>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<reference key="NSTarget" ref="524598165"/>
-												<string key="NSAction">_doScroller:</string>
-												<double key="NSPercent">0.98671726755218214</double>
-											</object>
-											<object class="NSScroller" id="802793151">
-												<reference key="NSNextResponder" ref="524598165"/>
-												<int key="NSvFlags">-2147483392</int>
-												<string key="NSFrame">{{1, 525}, {228, 15}}</string>
-												<reference key="NSSuperview" ref="524598165"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="735633081"/>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSsFlags">1</int>
-												<reference key="NSTarget" ref="524598165"/>
-												<string key="NSAction">_doScroller:</string>
-												<double key="NSPercent">0.99507391452789307</double>
-											</object>
-										</array>
-										<string key="NSFrame">{{0, 23}, {200, 489}}</string>
-										<reference key="NSSuperview" ref="551584428"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="233523429"/>
-										<int key="NSsFlags">133680</int>
-										<reference key="NSVScroller" ref="533108700"/>
-										<reference key="NSHScroller" ref="802793151"/>
-										<reference key="NSContentView" ref="233523429"/>
-										<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
-										<double key="NSMinMagnification">0.25</double>
-										<double key="NSMaxMagnification">4</double>
-										<double key="NSMagnification">1</double>
-									</object>
-								</array>
-								<string key="NSFrameSize">{200, 513}</string>
-								<reference key="NSSuperview" ref="616749187"/>
-								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="524598165"/>
-								<bool key="NSDoNotTranslateAutoresizingMask">YES</bool>
-							</object>
-							<object class="NSView" id="563806501">
-								<reference key="NSNextResponder" ref="616749187"/>
-								<int key="NSvFlags">274</int>
-								<array class="NSMutableArray" key="NSSubviews">
-									<object class="NSScrollView" id="1058735001">
-										<reference key="NSNextResponder" ref="563806501"/>
-										<int key="NSvFlags">274</int>
-										<array class="NSMutableArray" key="NSSubviews">
-											<object class="NSClipView" id="954788335">
-												<reference key="NSNextResponder" ref="1058735001"/>
-												<int key="NSvFlags">2322</int>
-												<array class="NSMutableArray" key="NSSubviews">
-													<object class="NSCustomView" id="315390047">
-														<reference key="NSNextResponder" ref="954788335"/>
-														<int key="NSvFlags">258</int>
-														<array class="NSMutableArray" key="NSSubviews">
-															<object class="NSCustomView" id="735564334">
-																<reference key="NSNextResponder" ref="315390047"/>
-																<int key="NSvFlags">301</int>
-																<array class="NSMutableArray" key="NSSubviews">
-																	<object class="NSCustomView" id="765073663">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">-2147483358</int>
-																		<array class="NSMutableArray" key="NSSubviews">
-																			<object class="NSButton" id="148626614">
-																				<reference key="NSNextResponder" ref="765073663"/>
-																				<int key="NSvFlags">268</int>
-																				<string key="NSFrame">{{159, 3}, {139, 28}}</string>
-																				<reference key="NSSuperview" ref="765073663"/>
-																				<reference key="NSWindow"/>
-																				<reference key="NSNextKeyView" ref="941479834"/>
-																				<bool key="NSEnabled">YES</bool>
-																				<object class="NSButtonCell" key="NSCell" id="1020482049">
-																					<int key="NSCellFlags">67108864</int>
-																					<int key="NSCellFlags2">134348800</int>
-																					<string key="NSContents">Save changes</string>
-																					<reference key="NSSupport" ref="26"/>
-																					<reference key="NSControlView" ref="148626614"/>
-																					<int key="NSButtonFlags">-2038284288</int>
-																					<int key="NSButtonFlags2">268435585</int>
-																					<string key="NSAlternateContents"/>
-																					<string key="NSKeyEquivalent">s</string>
-																					<int key="NSPeriodicDelay">200</int>
-																					<int key="NSPeriodicInterval">25</int>
-																				</object>
-																				<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																			</object>
-																			<object class="NSButton" id="463178943">
-																				<reference key="NSNextResponder" ref="765073663"/>
-																				<int key="NSvFlags">268</int>
-																				<string key="NSFrame">{{3, 3}, {157, 28}}</string>
-																				<reference key="NSSuperview" ref="765073663"/>
-																				<reference key="NSWindow"/>
-																				<reference key="NSNextKeyView" ref="148626614"/>
-																				<bool key="NSEnabled">YES</bool>
-																				<object class="NSButtonCell" key="NSCell" id="1027746126">
-																					<int key="NSCellFlags">67108864</int>
-																					<int key="NSCellFlags2">134348800</int>
-																					<string key="NSContents">Add to Favorites</string>
-																					<reference key="NSSupport" ref="26"/>
-																					<reference key="NSControlView" ref="463178943"/>
-																					<int key="NSButtonFlags">-2038284288</int>
-																					<int key="NSButtonFlags2">402653313</int>
-																					<string key="NSAlternateContents"/>
-																					<string key="NSKeyEquivalent">a</string>
-																					<int key="NSPeriodicDelay">200</int>
-																					<int key="NSPeriodicInterval">25</int>
-																				</object>
-																				<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																			</object>
-																			<object class="NSButton" id="941479834">
-																				<reference key="NSNextResponder" ref="765073663"/>
-																				<int key="NSvFlags">265</int>
-																				<string key="NSFrame">{{297, 3}, {146, 28}}</string>
-																				<reference key="NSSuperview" ref="765073663"/>
-																				<reference key="NSWindow"/>
-																				<reference key="NSNextKeyView" ref="460592307"/>
-																				<bool key="NSEnabled">YES</bool>
-																				<object class="NSButtonCell" key="NSCell" id="90221493">
-																					<int key="NSCellFlags">67108864</int>
-																					<int key="NSCellFlags2">134348800</int>
-																					<string key="NSContents">Test connection</string>
-																					<reference key="NSSupport" ref="26"/>
-																					<reference key="NSControlView" ref="941479834"/>
-																					<int key="NSButtonFlags">-2038284288</int>
-																					<int key="NSButtonFlags2">129</int>
-																					<string key="NSAlternateContents"/>
-																					<string key="NSKeyEquivalent"/>
-																					<int key="NSPeriodicDelay">200</int>
-																					<int key="NSPeriodicInterval">25</int>
-																				</object>
-																				<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																			</object>
-																		</array>
-																		<string key="NSFrameSize">{446, 37}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="463178943"/>
-																		<string key="NSClassName">NSView</string>
-																	</object>
-																	<object class="NSTabView" id="134031646">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">274</int>
-																		<string key="NSFrame">{{3, 61}, {440, 417}}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="159800861"/>
-																		<array class="NSMutableArray" key="NSTabViewItems">
-																			<object class="NSTabViewItem" id="253369045">
-																				<string key="NSIdentifier">1</string>
-																				<object class="NSView" key="NSView" id="32802602">
-																					<nil key="NSNextResponder"/>
-																					<int key="NSvFlags">274</int>
-																					<array class="NSMutableArray" key="NSSubviews">
-																						<object class="NSCustomView" id="233374444">
-																							<reference key="NSNextResponder" ref="32802602"/>
-																							<int key="NSvFlags">269</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSCustomView" id="134580562">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 208}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="786098118"/>
-																									<string key="NSClassName">SPColorSelectorView</string>
-																								</object>
-																								<object class="NSButton" id="508687946">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{108, 14}, {251, 18}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="31135925"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="184523755">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">0</int>
-																										<string key="NSContents">Connect using SSL</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="508687946"/>
-																										<int key="NSButtonFlags">1211912448</int>
-																										<int key="NSButtonFlags2">2</int>
-																										<object class="NSCustomResource" key="NSNormalImage" id="804903244">
-																											<string key="NSClassName">NSImage</string>
-																											<string key="NSResourceName">NSSwitch</string>
-																										</object>
-																										<object class="NSButtonImageSource" key="NSAlternateImage" id="791350007">
-																											<string key="NSImageName">NSSwitch</string>
-																										</object>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">200</int>
-																										<int key="NSPeriodicInterval">25</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="644973446">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 178}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="987440606"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="859982751">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="644973446"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<object class="NSColor" key="NSBackgroundColor" id="211632616">
-																											<int key="NSColorSpace">6</int>
-																											<string key="NSCatalogName">System</string>
-																											<string key="NSColorName">textBackgroundColor</string>
-																											<object class="NSColor" key="NSColor" id="402194341">
-																												<int key="NSColorSpace">3</int>
-																												<bytes key="NSWhite">MQA</bytes>
-																											</object>
-																										</object>
-																										<object class="NSColor" key="NSTextColor" id="395378299">
-																											<int key="NSColorSpace">6</int>
-																											<string key="NSCatalogName">System</string>
-																											<string key="NSColorName">textColor</string>
-																											<reference key="NSColor" ref="643097066"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="786098118">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 180}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="644973446"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="393023945">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Host:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="786098118"/>
-																										<object class="NSColor" key="NSBackgroundColor" id="644242225">
-																											<int key="NSColorSpace">6</int>
-																											<string key="NSCatalogName">System</string>
-																											<string key="NSColorName">controlColor</string>
-																											<object class="NSColor" key="NSColor" id="355746054">
-																												<int key="NSColorSpace">3</int>
-																												<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-																											</object>
-																										</object>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="810791200">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 238}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="134580562"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="1040289660">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="810791200"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="445567924">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 240}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="810791200"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="485990188">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Name:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="445567924"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="978463433">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 144}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="105635377"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="925313159">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="978463433"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="987440606">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 146}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="978463433"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="377431100">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Username:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="987440606"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="211629203">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 110}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="788113046"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="646391991">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="211629203"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="105635377">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 112}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="211629203"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="785119002">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Password:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="105635377"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="950381827">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 76}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="910543023"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="925102591">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="950381827"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="788113046">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 78}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="950381827"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="441978581">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Database:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="788113046"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="1013612483">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 42}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="508687946"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="1003825843">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">3306</string>
-																										<reference key="NSControlView" ref="1013612483"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="910543023">
-																									<reference key="NSNextResponder" ref="233374444"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 44}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="233374444"/>
-																									<reference key="NSNextKeyView" ref="1013612483"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="588889019">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Port:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="910543023"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, 101}, {377, 287}}</string>
-																							<reference key="NSSuperview" ref="32802602"/>
-																							<reference key="NSNextKeyView" ref="445567924"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																						<object class="NSCustomView" id="31135925">
-																							<reference key="NSNextResponder" ref="32802602"/>
-																							<int key="NSvFlags">268</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSTextField" id="104955330">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 15}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="638710413"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="69612386">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">CA Cert:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="104955330"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="638710413">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 13}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="839299955"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="791857368">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="638710413"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="839299955">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 12}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="990947983"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="1013426677">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="839299955"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<object class="NSCustomResource" key="NSNormalImage" id="792471251">
-																											<string key="NSClassName">NSImage</string>
-																											<string key="NSResourceName">key-icon</string>
-																										</object>
-																										<object class="NSCustomResource" key="NSAlternateImage" id="503225194">
-																											<string key="NSClassName">NSImage</string>
-																											<string key="NSResourceName">key-icon-alternate</string>
-																										</object>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="684819179">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 49}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="950540175"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="371333119">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Certificate:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="684819179"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="950540175">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 47}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="945929172"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="196185392">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="950540175"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="945929172">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 46}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="104955330"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="1000000271">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="945929172"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="1034069158">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 83}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="679511995"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="943522732">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Key File:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="1034069158"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="679511995">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 81}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="586011242"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="650760201">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="679511995"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41MDQwMzIyNTQyAA</bytes>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="586011242">
-																									<reference key="NSNextResponder" ref="31135925"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 80}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="31135925"/>
-																									<reference key="NSNextKeyView" ref="684819179"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="85329089">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="586011242"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, -3}, {377, 104}}</string>
-																							<reference key="NSSuperview" ref="32802602"/>
-																							<reference key="NSNextKeyView" ref="1034069158"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																					</array>
-																					<string key="NSFrame">{{10, 33}, {420, 371}}</string>
-																					<reference key="NSNextKeyView" ref="233374444"/>
-																				</object>
-																				<string key="NSLabel">Standard</string>
-																				<reference key="NSColor" ref="644242225"/>
-																				<reference key="NSTabView" ref="134031646"/>
-																			</object>
-																			<object class="NSTabViewItem" id="517771995">
-																				<string key="NSIdentifier">2</string>
-																				<object class="NSView" key="NSView" id="962671066">
-																					<nil key="NSNextResponder"/>
-																					<int key="NSvFlags">274</int>
-																					<array class="NSMutableArray" key="NSSubviews">
-																						<object class="NSCustomView" id="394302879">
-																							<reference key="NSNextResponder" ref="962671066"/>
-																							<int key="NSvFlags">269</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSCustomView" id="247616432">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 167}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="607362814"/>
-																									<string key="NSClassName">SPColorSelectorView</string>
-																								</object>
-																								<object class="NSButton" id="16421625">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{108, 7}, {251, 18}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="866600720"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="972347112">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">0</int>
-																										<string key="NSContents">Connect using SSL</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="16421625"/>
-																										<int key="NSButtonFlags">1211912448</int>
-																										<int key="NSButtonFlags2">2</int>
-																										<reference key="NSNormalImage" ref="804903244"/>
-																										<reference key="NSAlternateImage" ref="791350007"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">200</int>
-																										<int key="NSPeriodicInterval">25</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="68541783">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 137}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="789391730"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="279442436">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="68541783"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="607362814">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 139}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="68541783"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="798396187">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Username:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="607362814"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="512253301">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 103}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="745773732"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="251554254">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="512253301"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="789391730">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 105}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="512253301"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="797213431">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Password:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="789391730"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="58217156">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 69}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="591324856"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="185246669">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="58217156"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="745773732">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 71}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="58217156"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="728524936">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Database:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="745773732"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="728228957">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 35}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="16421625"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="299457759">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="728228957"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="591324856">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 37}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="728228957"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="317867885">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Socket:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="591324856"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="474825058">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 197}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="247616432"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="684614893">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="474825058"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="459734357">
-																									<reference key="NSNextResponder" ref="394302879"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 199}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="394302879"/>
-																									<reference key="NSNextKeyView" ref="474825058"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="352725628">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Name:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="459734357"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, 142}, {377, 246}}</string>
-																							<reference key="NSSuperview" ref="962671066"/>
-																							<reference key="NSNextKeyView" ref="459734357"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																						<object class="NSCustomView" id="866600720">
-																							<reference key="NSNextResponder" ref="962671066"/>
-																							<int key="NSvFlags">268</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSTextField" id="98826968">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 15}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="484504415"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="730590428">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">CA Cert:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="98826968"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="484504415">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 13}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="680939705"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="169093017">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="484504415"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="680939705">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 12}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="308087760">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="680939705"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="521125104">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 49}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="216069484"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="1025158673">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Certificate:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="521125104"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="216069484">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 47}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="988136593"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="276609847">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="216069484"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="988136593">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 46}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="98826968"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="559442548">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="988136593"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="57862599">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 83}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="51601157"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="357553281">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Key File:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="57862599"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="51601157">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 81}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="237955939"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="575863174">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="51601157"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41MDQwMzIyNTQyAA</bytes>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="237955939">
-																									<reference key="NSNextResponder" ref="866600720"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 80}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="866600720"/>
-																									<reference key="NSNextKeyView" ref="521125104"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="167444868">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="237955939"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, 38}, {377, 104}}</string>
-																							<reference key="NSSuperview" ref="962671066"/>
-																							<reference key="NSNextKeyView" ref="57862599"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																					</array>
-																					<string key="NSFrame">{{10, 33}, {420, 371}}</string>
-																					<reference key="NSNextKeyView" ref="394302879"/>
-																				</object>
-																				<string key="NSLabel">Socket</string>
-																				<reference key="NSColor" ref="644242225"/>
-																				<reference key="NSTabView" ref="134031646"/>
-																			</object>
-																			<object class="NSTabViewItem" id="591192172">
-																				<string key="NSIdentifier">Item 2</string>
-																				<object class="NSView" key="NSView" id="159800861">
-																					<reference key="NSNextResponder" ref="134031646"/>
-																					<int key="NSvFlags">274</int>
-																					<array class="NSMutableArray" key="NSSubviews">
-																						<object class="NSCustomView" id="326102394">
-																							<reference key="NSNextResponder" ref="159800861"/>
-																							<int key="NSvFlags">269</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSButton" id="1003668465">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{108, 3}, {251, 18}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="709218819"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="994249095">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">0</int>
-																										<string key="NSContents">Connect using SSL</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="1003668465"/>
-																										<int key="NSButtonFlags">1211912448</int>
-																										<int key="NSButtonFlags2">2</int>
-																										<reference key="NSNormalImage" ref="804903244"/>
-																										<reference key="NSAlternateImage" ref="791350007"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">200</int>
-																										<int key="NSPeriodicInterval">25</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSCustomView" id="941551595">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 343}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="615962367"/>
-																									<string key="NSClassName">SPColorSelectorView</string>
-																								</object>
-																								<object class="NSTextField" id="1030226140">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 313}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="189856761"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="933547668">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="1030226140"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="615962367">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 315}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="1030226140"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="547674489">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">MySQL Host:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="615962367"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="358903996">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 279}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="71258292"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="869330413">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="358903996"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="189856761">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 281}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="358903996"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="218707841">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Username:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="189856761"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="187191991">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 245}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="632758915"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="737530250">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="187191991"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="71258292">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 247}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="187191991"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="1056521404">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Password:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="71258292"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="1000646962">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 211}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="914345743"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="289965133">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="1000646962"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="632758915">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 213}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="1000646962"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="664433389">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Database:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="632758915"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="1049720725">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 177}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="81612279"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="615536496">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">3306</string>
-																										<reference key="NSControlView" ref="1049720725"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="914345743">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{10, 179}, {95, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="1049720725"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="265944034">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Port:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="914345743"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="844385120">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 129}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="558754343"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="505035309">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="844385120"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="81612279">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{10, 131}, {95, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="844385120"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="386177793">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">SSH Host:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="81612279"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="790983747">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 95}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="906103858"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="347555313">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="790983747"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="558754343">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 97}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="790983747"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="222275233">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">SSH User:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="558754343"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="21480939">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 61}, {219, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="183948302"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="944931136">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="21480939"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="627782947">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 63}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="180145997"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="369035253">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">SSH Password:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="627782947"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="692784990">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 27}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="1003668465"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="850057181">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="692784990"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="984151006">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 29}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="692784990"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="563972303">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">SSH Port:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="984151006"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="1022082829">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 373}, {247, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="941551595"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="833542503">
-																										<int key="NSCellFlags">-1804599231</int>
-																										<int key="NSCellFlags2">272630848</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">optional</string>
-																										<reference key="NSControlView" ref="1022082829"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<reference key="NSTextColor" ref="395378299"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="761323775">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 375}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="1022082829"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="906889126">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Name:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="761323775"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="183948302">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 60}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="984151006"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="510891456">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="183948302"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="906103858">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{7, 63}, {98, 17}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="627782947"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="882604644">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">SSH Key:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="906103858"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="180145997">
-																									<reference key="NSNextResponder" ref="326102394"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{110, 61}, {219, 22}}</string>
-																									<reference key="NSSuperview" ref="326102394"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="21480939"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="13940444">
-																										<int key="NSCellFlags">-2076180416</int>
-																										<int key="NSCellFlags2">272631360</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="180145997"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC40OTU5Njc3NDU4AA</bytes>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, -34}, {377, 422}}</string>
-																							<reference key="NSSuperview" ref="159800861"/>
-																							<reference key="NSWindow"/>
-																							<reference key="NSNextKeyView" ref="761323775"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																						<object class="NSCustomView" id="709218819">
-																							<reference key="NSNextResponder" ref="159800861"/>
-																							<int key="NSvFlags">268</int>
-																							<array class="NSMutableArray" key="NSSubviews">
-																								<object class="NSTextField" id="621104276">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 15}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="258381978"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="781228352">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">CA Cert:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="621104276"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="258381978">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 13}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="666556728"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="79502833">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="258381978"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="666556728">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 12}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="134031646"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="345867488">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="666556728"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="229099685">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 49}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="206891834"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="371886454">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Certificate:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="229099685"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="206891834">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 47}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="142713239"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="624179436">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="206891834"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41AA</bytes>
-																											<reference key="NSCustomColorSpace" ref="886601921"/>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="142713239">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 46}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="621104276"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="946439447">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="142713239"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																								<object class="NSTextField" id="700963246">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{-3, 83}, {107, 17}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="436440005"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="505754417">
-																										<int key="NSCellFlags">68157504</int>
-																										<int key="NSCellFlags2">71304192</int>
-																										<string key="NSContents">Key File:</string>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="700963246"/>
-																										<reference key="NSBackgroundColor" ref="644242225"/>
-																										<reference key="NSTextColor" ref="434026568"/>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSTextField" id="436440005">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{109, 81}, {220, 22}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="165705421"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSTextFieldCell" key="NSCell" id="314304383">
-																										<int key="NSCellFlags">-2074083263</int>
-																										<int key="NSCellFlags2">272631296</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<string key="NSPlaceholderString">none set</string>
-																										<reference key="NSControlView" ref="436440005"/>
-																										<bool key="NSDrawsBackground">YES</bool>
-																										<reference key="NSBackgroundColor" ref="211632616"/>
-																										<object class="NSColor" key="NSTextColor">
-																											<int key="NSColorSpace">3</int>
-																											<bytes key="NSWhite">MC41MDQwMzIyNTQyAA</bytes>
-																										</object>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																									<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																								</object>
-																								<object class="NSButton" id="165705421">
-																									<reference key="NSNextResponder" ref="709218819"/>
-																									<int key="NSvFlags">268</int>
-																									<string key="NSFrame">{{328, 80}, {29, 24}}</string>
-																									<reference key="NSSuperview" ref="709218819"/>
-																									<reference key="NSWindow"/>
-																									<reference key="NSNextKeyView" ref="229099685"/>
-																									<bool key="NSEnabled">YES</bool>
-																									<object class="NSButtonCell" key="NSCell" id="74900653">
-																										<int key="NSCellFlags">67108864</int>
-																										<int key="NSCellFlags2">134217728</int>
-																										<string key="NSContents"/>
-																										<reference key="NSSupport" ref="807120225"/>
-																										<reference key="NSControlView" ref="165705421"/>
-																										<int key="NSButtonFlags">-922992640</int>
-																										<int key="NSButtonFlags2">34</int>
-																										<reference key="NSNormalImage" ref="792471251"/>
-																										<reference key="NSAlternateImage" ref="503225194"/>
-																										<string key="NSAlternateContents"/>
-																										<string key="NSKeyEquivalent"/>
-																										<int key="NSPeriodicDelay">400</int>
-																										<int key="NSPeriodicInterval">75</int>
-																									</object>
-																									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																								</object>
-																							</array>
-																							<string key="NSFrame">{{22, -146}, {377, 104}}</string>
-																							<reference key="NSSuperview" ref="159800861"/>
-																							<reference key="NSWindow"/>
-																							<reference key="NSNextKeyView" ref="700963246"/>
-																							<string key="NSClassName">NSView</string>
-																						</object>
-																					</array>
-																					<string key="NSFrame">{{10, 33}, {420, 371}}</string>
-																					<reference key="NSSuperview" ref="134031646"/>
-																					<reference key="NSWindow"/>
-																					<reference key="NSNextKeyView" ref="326102394"/>
-																				</object>
-																				<string key="NSLabel">SSH</string>
-																				<reference key="NSColor" ref="644242225"/>
-																				<reference key="NSTabView" ref="134031646"/>
-																			</object>
-																		</array>
-																		<reference key="NSSelectedTabViewItem" ref="591192172"/>
-																		<reference key="NSFont" ref="807120225"/>
-																		<int key="NSTvFlags">0</int>
-																		<bool key="NSAllowTruncatedLabels">YES</bool>
-																		<bool key="NSDrawsBackground">YES</bool>
-																		<array class="NSMutableArray" key="NSSubviews">
-																			<reference ref="159800861"/>
-																		</array>
-																	</object>
-																	<object class="NSButton" id="460592307">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">289</int>
-																		<string key="NSFrame">{{295, 33}, {147, 32}}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="108277656"/>
-																		<bool key="NSEnabled">YES</bool>
-																		<object class="NSButtonCell" key="NSCell" id="424756162">
-																			<int key="NSCellFlags">67108864</int>
-																			<int key="NSCellFlags2">134217728</int>
-																			<string key="NSContents">Connect</string>
-																			<reference key="NSSupport" ref="807120225"/>
-																			<reference key="NSControlView" ref="460592307"/>
-																			<int key="NSButtonFlags">-2038284288</int>
-																			<int key="NSButtonFlags2">129</int>
-																			<string key="NSAlternateContents"/>
-																			<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-																			<int key="NSPeriodicDelay">200</int>
-																			<int key="NSPeriodicInterval">25</int>
-																		</object>
-																		<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	</object>
-																	<object class="NSProgressIndicator" id="575228526">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">1316</int>
-																		<string key="NSFrame">{{7, 43}, {16, 16}}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="549907703"/>
-																		<int key="NSpiFlags">28938</int>
-																		<double key="NSMinValue">16</double>
-																		<double key="NSMaxValue">100</double>
-																	</object>
-																	<object class="NSTextField" id="549907703">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">-2147483356</int>
-																		<string key="NSFrame">{{29, 43}, {264, 17}}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="765073663"/>
-																		<bool key="NSEnabled">YES</bool>
-																		<object class="NSTextFieldCell" key="NSCell" id="321846713">
-																			<int key="NSCellFlags">68157504</int>
-																			<int key="NSCellFlags2">272630784</int>
-																			<string key="NSContents">Connecting...</string>
-																			<reference key="NSSupport" ref="807120225"/>
-																			<reference key="NSControlView" ref="549907703"/>
-																			<reference key="NSBackgroundColor" ref="644242225"/>
-																			<reference key="NSTextColor" ref="434026568"/>
-																		</object>
-																		<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																		<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-																	</object>
-																	<object class="NSButton" id="990947983">
-																		<reference key="NSNextResponder" ref="735564334"/>
-																		<int key="NSvFlags">292</int>
-																		<string key="NSFrame">{{3, 37}, {25, 25}}</string>
-																		<reference key="NSSuperview" ref="735564334"/>
-																		<reference key="NSWindow"/>
-																		<reference key="NSNextKeyView" ref="575228526"/>
-																		<bool key="NSEnabled">YES</bool>
-																		<object class="NSButtonCell" key="NSCell" id="757039715">
-																			<int key="NSCellFlags">-2080374784</int>
-																			<int key="NSCellFlags2">134217728</int>
-																			<string key="NSContents"/>
-																			<reference key="NSSupport" ref="807120225"/>
-																			<reference key="NSControlView" ref="990947983"/>
-																			<int key="NSButtonFlags">-2038415360</int>
-																			<int key="NSButtonFlags2">33</int>
-																			<string key="NSAlternateContents"/>
-																			<string key="NSKeyEquivalent"/>
-																			<int key="NSPeriodicDelay">200</int>
-																			<int key="NSPeriodicInterval">25</int>
-																		</object>
-																		<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	</object>
-																</array>
-																<string key="NSFrame">{{116, 5}, {446, 472}}</string>
-																<reference key="NSSuperview" ref="315390047"/>
-																<reference key="NSWindow"/>
-																<reference key="NSNextKeyView" ref="134031646"/>
-																<string key="NSClassName">NSCustomView</string>
-															</object>
-														</array>
-														<string key="NSFrameSize">{681, 480}</string>
-														<reference key="NSSuperview" ref="954788335"/>
-														<reference key="NSWindow"/>
-														<reference key="NSNextKeyView" ref="735564334"/>
-														<string key="NSClassName">SPFlippedView</string>
-													</object>
-												</array>
-												<string key="NSFrameSize">{681, 481}</string>
-												<reference key="NSSuperview" ref="1058735001"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="315390047"/>
-												<reference key="NSDocView" ref="315390047"/>
-												<reference key="NSBGColor" ref="644242225"/>
-												<int key="NScvFlags">4</int>
-											</object>
-											<object class="NSScroller" id="508899576">
-												<reference key="NSNextResponder" ref="1058735001"/>
-												<int key="NSvFlags">-2147483392</int>
-												<string key="NSFrame">{{663, 0}, {16, 580}}</string>
-												<reference key="NSSuperview" ref="1058735001"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView"/>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<reference key="NSTarget" ref="1058735001"/>
-												<string key="NSAction">_doScroller:</string>
-												<double key="NSCurValue">1</double>
-												<double key="NSPercent">0.97083333333333333</double>
-											</object>
-											<object class="NSScroller" id="108277656">
-												<reference key="NSNextResponder" ref="1058735001"/>
-												<int key="NSvFlags">-2147483392</int>
-												<string key="NSFrame">{{0, 466}, {663, 15}}</string>
-												<reference key="NSSuperview" ref="1058735001"/>
-												<reference key="NSWindow"/>
-												<reference key="NSNextKeyView" ref="508899576"/>
-												<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												<int key="NSsFlags">1</int>
-												<reference key="NSTarget" ref="1058735001"/>
-												<string key="NSAction">_doScroller:</string>
-												<double key="NSPercent">0.9779086892488954</double>
-											</object>
-										</array>
-										<string key="NSFrameSize">{681, 481}</string>
-										<reference key="NSSuperview" ref="563806501"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="954788335"/>
-										<int key="NSsFlags">133680</int>
-										<reference key="NSVScroller" ref="508899576"/>
-										<reference key="NSHScroller" ref="108277656"/>
-										<reference key="NSContentView" ref="954788335"/>
-										<double key="NSMinMagnification">0.25</double>
-										<double key="NSMaxMagnification">4</double>
-										<double key="NSMagnification">1</double>
-									</object>
-									<object class="NSTextField" id="570492783">
-										<reference key="NSNextResponder" ref="563806501"/>
-										<int key="NSvFlags">266</int>
-										<string key="NSFrame">{{17, 489}, {647, 17}}</string>
-										<reference key="NSSuperview" ref="563806501"/>
-										<reference key="NSWindow"/>
-										<reference key="NSNextKeyView" ref="1058735001"/>
-										<bool key="NSEnabled">YES</bool>
-										<object class="NSTextFieldCell" key="NSCell" id="607446274">
-											<int key="NSCellFlags">68157504</int>
-											<int key="NSCellFlags2">138413056</int>
-											<string key="NSContents">Enter connection details below, or choose a favorite</string>
-											<object class="NSFont" key="NSSupport">
-												<bool key="IBIsSystemFont">YES</bool>
-												<double key="NSSize">13</double>
-												<int key="NSfFlags">2072</int>
-											</object>
-											<reference key="NSControlView" ref="570492783"/>
-											<reference key="NSBackgroundColor" ref="644242225"/>
-											<reference key="NSTextColor" ref="434026568"/>
-										</object>
-										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-										<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-									</object>
-								</array>
-								<string key="NSFrame">{{201, 0}, {681, 513}}</string>
-								<reference key="NSSuperview" ref="616749187"/>
-								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView" ref="570492783"/>
-								<bool key="NSDoNotTranslateAutoresizingMask">YES</bool>
-							</object>
-						</array>
-						<string key="NSFrameSize">{882, 513}</string>
-						<reference key="NSSuperview" ref="733821228"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="551584428"/>
-						<bool key="NSIsVertical">YES</bool>
-						<int key="NSDividerStyle">2</int>
-						<string key="NSAutosaveName">DBViewSplitter</string>
-					</object>
-				</array>
-				<string key="NSFrameSize">{882, 513}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="616749187"/>
-				<string key="NSClassName">SPFlippedView</string>
-			</object>
-			<object class="NSWindowTemplate" id="958272936">
-				<int key="NSWindowStyleMask">8223</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{439, 291}, {580, 320}}</string>
-				<int key="NSWTFlags">-469762048</int>
-				<string key="NSWindowTitle">Error Detail</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{100, 100}</string>
-				<object class="NSView" key="NSWindowView" id="536120400">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSScrollView" id="699163511">
-							<reference key="NSNextResponder" ref="536120400"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSClipView" id="547900823">
-									<reference key="NSNextResponder" ref="699163511"/>
-									<int key="NSvFlags">2304</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSTextView" id="59706192">
-											<reference key="NSNextResponder" ref="547900823"/>
-											<int key="NSvFlags">2322</int>
-											<string key="NSFrameSize">{578, 293}</string>
-											<reference key="NSSuperview" ref="547900823"/>
-											<object class="NSTextContainer" key="NSTextContainer" id="646915301">
-												<object class="NSLayoutManager" key="NSLayoutManager">
-													<object class="NSTextStorage" key="NSTextStorage">
-														<object class="NSMutableString" key="NSString">
-															<characters key="NS.bytes">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum Et harumd und lookum like Greek to me, dereud facilis est er expedit distinct. Nam liber te conscient to factor tum poen legum odioque civiuda</characters>
-														</object>
-														<array class="NSMutableArray" key="NSAttributes">
-															<dictionary>
-																<object class="NSColor" key="NSColor" id="674452854">
-																	<int key="NSColorSpace">1</int>
-																	<bytes key="NSRGB">MC45MDE5NjA3OSAwLjkwMTk2MDc5IDAuOTAxOTYwNzkAA</bytes>
-																</object>
-																<object class="NSFont" key="NSFont">
-																	<bool key="IBIsSystemFont">YES</bool>
-																	<double key="NSSize">10</double>
-																	<int key="NSfFlags">2843</int>
-																</object>
-																<object class="NSParagraphStyle" key="NSParagraphStyle">
-																	<int key="NSAlignment">3</int>
-																	<array key="NSTabStops">
-																		<object class="NSTextTab" id="823634743">
-																			<double key="NSLocation">0.0</double>
-																		</object>
-																		<object class="NSTextTab" id="713375536">
-																			<double key="NSLocation">56</double>
-																		</object>
-																		<object class="NSTextTab" id="999774917">
-																			<double key="NSLocation">112</double>
-																		</object>
-																		<object class="NSTextTab" id="634012080">
-																			<double key="NSLocation">168</double>
-																		</object>
-																		<object class="NSTextTab" id="782574576">
-																			<double key="NSLocation">224</double>
-																		</object>
-																		<object class="NSTextTab" id="19717301">
-																			<double key="NSLocation">280</double>
-																		</object>
-																		<object class="NSTextTab" id="937773658">
-																			<double key="NSLocation">336</double>
-																		</object>
-																		<object class="NSTextTab" id="219483472">
-																			<double key="NSLocation">392</double>
-																		</object>
-																		<object class="NSTextTab" id="878853441">
-																			<double key="NSLocation">448</double>
-																		</object>
-																		<object class="NSTextTab" id="618333087">
-																			<double key="NSLocation">504</double>
-																		</object>
-																		<object class="NSTextTab" id="820362010">
-																			<double key="NSLocation">560</double>
-																		</object>
-																		<object class="NSTextTab" id="470724251">
-																			<double key="NSLocation">616</double>
-																		</object>
-																		<object class="NSTextTab" id="56552689">
-																			<double key="NSLocation">672</double>
-																		</object>
-																		<object class="NSTextTab" id="65501475">
-																			<double key="NSLocation">728</double>
-																		</object>
-																		<object class="NSTextTab" id="469693015">
-																			<double key="NSLocation">784</double>
-																		</object>
-																		<object class="NSTextTab" id="334479669">
-																			<double key="NSLocation">840</double>
-																		</object>
-																		<object class="NSTextTab" id="367366098">
-																			<double key="NSLocation">896</double>
-																		</object>
-																		<object class="NSTextTab" id="11887200">
-																			<double key="NSLocation">952</double>
-																		</object>
-																		<object class="NSTextTab" id="613253918">
-																			<double key="NSLocation">1008</double>
-																		</object>
-																		<object class="NSTextTab" id="683900068">
-																			<double key="NSLocation">1064</double>
-																		</object>
-																		<object class="NSTextTab" id="640062352">
-																			<double key="NSLocation">1120</double>
-																		</object>
-																		<object class="NSTextTab" id="953428032">
-																			<double key="NSLocation">1176</double>
-																		</object>
-																		<object class="NSTextTab" id="916708773">
-																			<double key="NSLocation">1232</double>
-																		</object>
-																		<object class="NSTextTab" id="777694472">
-																			<double key="NSLocation">1288</double>
-																		</object>
-																		<object class="NSTextTab" id="193444438">
-																			<double key="NSLocation">1344</double>
-																		</object>
-																		<object class="NSTextTab" id="392872653">
-																			<double key="NSLocation">1400</double>
-																		</object>
-																		<object class="NSTextTab" id="459383765">
-																			<double key="NSLocation">1456</double>
-																		</object>
-																		<object class="NSTextTab" id="729563838">
-																			<double key="NSLocation">1512</double>
-																		</object>
-																		<object class="NSTextTab" id="18292341">
-																			<double key="NSLocation">1568</double>
-																		</object>
-																		<object class="NSTextTab" id="1007283588">
-																			<double key="NSLocation">1624</double>
-																		</object>
-																		<object class="NSTextTab" id="133675098">
-																			<double key="NSLocation">1680</double>
-																		</object>
-																		<object class="NSTextTab" id="841926084">
-																			<double key="NSLocation">1736</double>
-																		</object>
-																	</array>
-																</object>
-															</dictionary>
-															<dictionary>
-																<reference key="NSColor" ref="674452854"/>
-																<object class="NSFont" key="NSFont">
-																	<string key="NSName">LucidaGrande-Bold</string>
-																	<double key="NSSize">10</double>
-																	<int key="NSfFlags">16</int>
-																</object>
-																<object class="NSParagraphStyle" key="NSParagraphStyle">
-																	<int key="NSAlignment">3</int>
-																	<array key="NSTabStops">
-																		<reference ref="823634743"/>
-																		<reference ref="713375536"/>
-																		<reference ref="999774917"/>
-																		<reference ref="634012080"/>
-																		<reference ref="782574576"/>
-																		<reference ref="19717301"/>
-																		<reference ref="937773658"/>
-																		<reference ref="219483472"/>
-																		<reference ref="878853441"/>
-																		<reference ref="618333087"/>
-																		<reference ref="820362010"/>
-																		<reference ref="470724251"/>
-																		<reference ref="56552689"/>
-																		<reference ref="65501475"/>
-																		<reference ref="469693015"/>
-																		<reference ref="334479669"/>
-																		<reference ref="367366098"/>
-																		<reference ref="11887200"/>
-																		<reference ref="613253918"/>
-																		<reference ref="683900068"/>
-																		<reference ref="640062352"/>
-																		<reference ref="953428032"/>
-																		<reference ref="916708773"/>
-																		<reference ref="777694472"/>
-																		<reference ref="193444438"/>
-																		<reference ref="392872653"/>
-																		<reference ref="459383765"/>
-																		<reference ref="729563838"/>
-																		<reference ref="18292341"/>
-																		<reference ref="1007283588"/>
-																		<reference ref="133675098"/>
-																		<reference ref="841926084"/>
-																	</array>
-																</object>
-															</dictionary>
-														</array>
-														<object class="NSMutableData" key="NSAttributeInfo">
-															<bytes key="NS.bytes">GQAEAQgADAEiAAcBhAQAA</bytes>
-														</object>
-														<nil key="NSDelegate"/>
-													</object>
-													<array class="NSMutableArray" key="NSTextContainers">
-														<reference ref="646915301"/>
-													</array>
-													<int key="NSLMFlags">38</int>
-													<nil key="NSDelegate"/>
-												</object>
-												<reference key="NSTextView" ref="59706192"/>
-												<double key="NSWidth">578</double>
-												<int key="NSTCFlags">1</int>
-											</object>
-											<object class="NSTextViewSharedData" key="NSSharedData">
-												<int key="NSFlags">2053</int>
-												<int key="NSTextCheckingTypes">0</int>
-												<nil key="NSMarkedAttributes"/>
-												<reference key="NSBackgroundColor" ref="402194341"/>
-												<dictionary key="NSSelectedAttributes">
-													<object class="NSColor" key="NSBackgroundColor">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">selectedTextBackgroundColor</string>
-														<reference key="NSColor" ref="355746054"/>
-													</object>
-													<object class="NSColor" key="NSColor">
-														<int key="NSColorSpace">6</int>
-														<string key="NSCatalogName">System</string>
-														<string key="NSColorName">selectedTextColor</string>
-														<reference key="NSColor" ref="643097066"/>
-													</object>
-												</dictionary>
-												<reference key="NSInsertionColor" ref="643097066"/>
-												<dictionary key="NSLinkAttributes">
-													<reference key="NSColor" ref="981160636"/>
-													<integer value="1" key="NSUnderline"/>
-												</dictionary>
-												<nil key="NSDefaultParagraphStyle"/>
-												<nil key="NSTextFinder"/>
-												<int key="NSPreferredTextFinderStyle">0</int>
-											</object>
-											<int key="NSTVFlags">6</int>
-											<string key="NSMaxSize">{1156, 10000000}</string>
-											<nil key="NSDelegate"/>
-										</object>
-									</array>
-									<string key="NSFrameSize">{578, 293}</string>
-									<reference key="NSSuperview" ref="699163511"/>
-									<reference key="NSNextKeyView" ref="59706192"/>
-									<reference key="NSDocView" ref="59706192"/>
-									<object class="NSColor" key="NSBGColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MSAwAA</bytes>
-									</object>
-									<object class="NSCursor" key="NSCursor">
-										<string key="NSHotSpot">{4, 5}</string>
-										<object class="NSImage" key="NSImage">
-											<int key="NSImageFlags">79691776</int>
-											<array key="NSReps">
-												<array>
-													<integer value="5"/>
-													<object class="NSURL">
-														<nil key="NS.base"/>
-														<string key="NS.relative">file:///Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff</string>
-													</object>
-												</array>
-											</array>
-											<object class="NSColor" key="NSColor">
-												<int key="NSColorSpace">3</int>
-												<bytes key="NSWhite">MCAwAA</bytes>
-											</object>
-										</object>
-									</object>
-									<int key="NScvFlags">2</int>
-								</object>
-								<object class="NSScroller" id="79422493">
-									<reference key="NSNextResponder" ref="699163511"/>
-									<int key="NSvFlags">-2147483392</int>
-									<string key="NSFrame">{{566, 0}, {12, 293}}</string>
-									<reference key="NSSuperview" ref="699163511"/>
-									<bool key="NSEnabled">YES</bool>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<int key="NSArrowsLoc">2</int>
-									<reference key="NSTarget" ref="699163511"/>
-									<string key="NSAction">_doScroller:</string>
-									<double key="NSPercent">0.95705521106719971</double>
-								</object>
-								<object class="NSScroller" id="266224177">
-									<reference key="NSNextResponder" ref="699163511"/>
-									<int key="NSvFlags">-2147483392</int>
-									<string key="NSFrame">{{-100, -100}, {87, 18}}</string>
-									<reference key="NSSuperview" ref="699163511"/>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<int key="NSsFlags">1</int>
-									<reference key="NSTarget" ref="699163511"/>
-									<string key="NSAction">_doScroller:</string>
-									<double key="NSCurValue">1</double>
-									<double key="NSPercent">0.94565218687057495</double>
-								</object>
-							</array>
-							<string key="NSFrame">{{1, 20}, {578, 293}}</string>
-							<reference key="NSSuperview" ref="536120400"/>
-							<reference key="NSNextKeyView" ref="547900823"/>
-							<int key="NSsFlags">133648</int>
-							<reference key="NSVScroller" ref="79422493"/>
-							<reference key="NSHScroller" ref="266224177"/>
-							<reference key="NSContentView" ref="547900823"/>
-							<double key="NSMinMagnification">0.25</double>
-							<double key="NSMaxMagnification">4</double>
-							<double key="NSMagnification">1</double>
-						</object>
-					</array>
-					<string key="NSFrameSize">{580, 320}</string>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1920, 1178}}</string>
-				<string key="NSMinSize">{100, 119}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<string key="NSFrameAutosaveName"/>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSUserDefaultsController" id="642702582">
-				<bool key="NSSharedInstance">YES</bool>
-			</object>
-			<object class="NSCustomView" id="567906875">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSButton" id="912885202">
-						<reference key="NSNextResponder" ref="567906875"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{14, 14}, {273, 18}}</string>
-						<reference key="NSSuperview" ref="567906875"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="388136120">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">0</int>
-							<string key="NSContents">Show hidden files</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="912885202"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="804903244"/>
-							<reference key="NSAlternateImage" ref="791350007"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="44241774">
-						<reference key="NSNextResponder" ref="567906875"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{2, 42}, {575, 34}}</string>
-						<reference key="NSSuperview" ref="567906875"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="1045018411">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">138674176</int>
-							<string key="NSContents">Choose a custom SSH key file to use with this connection. Note that standard locations like ~/.ssh are checked automatically, as are any files in your SSH configuration.</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="44241774"/>
-							<reference key="NSBackgroundColor" ref="644242225"/>
-							<reference key="NSTextColor" ref="434026568"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-				</array>
-				<string key="NSFrameSize">{579, 83}</string>
-				<string key="NSClassName">NSView</string>
-			</object>
-			<object class="NSCustomView" id="12066713">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSButton" id="388256324">
-						<reference key="NSNextResponder" ref="12066713"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{14, 14}, {273, 18}}</string>
-						<reference key="NSSuperview" ref="12066713"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="844788897">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">0</int>
-							<string key="NSContents">Show hidden files</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="388256324"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="804903244"/>
-							<reference key="NSAlternateImage" ref="791350007"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="538839943">
-						<reference key="NSNextResponder" ref="12066713"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{2, 42}, {575, 17}}</string>
-						<reference key="NSSuperview" ref="12066713"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="124352014">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">138674176</int>
-							<string key="NSContents">Please select the SSL key file to use when establishing a secure connection.</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="538839943"/>
-							<reference key="NSBackgroundColor" ref="644242225"/>
-							<reference key="NSTextColor" ref="434026568"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-				</array>
-				<string key="NSFrameSize">{579, 66}</string>
-				<string key="NSClassName">NSView</string>
-			</object>
-			<object class="NSCustomView" id="136328549">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSButton" id="103272364">
-						<reference key="NSNextResponder" ref="136328549"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{14, 14}, {273, 18}}</string>
-						<reference key="NSSuperview" ref="136328549"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="20247014">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">0</int>
-							<string key="NSContents">Show hidden files</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="103272364"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="804903244"/>
-							<reference key="NSAlternateImage" ref="791350007"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="802544195">
-						<reference key="NSNextResponder" ref="136328549"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{6, 42}, {576, 17}}</string>
-						<reference key="NSSuperview" ref="136328549"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="196059550">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">138674176</int>
-							<string key="NSContents">Please select the client SSL certificate file to use when establishing a secure connection.</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="802544195"/>
-							<reference key="NSBackgroundColor" ref="644242225"/>
-							<reference key="NSTextColor" ref="434026568"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-				</array>
-				<string key="NSFrameSize">{599, 66}</string>
-				<string key="NSClassName">NSView</string>
-			</object>
-			<object class="NSCustomView" id="3577372">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSButton" id="455655503">
-						<reference key="NSNextResponder" ref="3577372"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{14, 14}, {273, 18}}</string>
-						<reference key="NSSuperview" ref="3577372"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="609741956">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">0</int>
-							<string key="NSContents">Show hidden files</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="455655503"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="804903244"/>
-							<reference key="NSAlternateImage" ref="791350007"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="761812578">
-						<reference key="NSNextResponder" ref="3577372"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{2, 42}, {575, 34}}</string>
-						<reference key="NSSuperview" ref="3577372"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="444474564">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">138674176</int>
-							<string key="NSContents">Please select the client SSL Certificate Authority certificate to use when establishing a secure connection.  This must be the same as the server CA certificate.</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="761812578"/>
-							<reference key="NSBackgroundColor" ref="644242225"/>
-							<reference key="NSTextColor" ref="434026568"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-				</array>
-				<string key="NSFrameSize">{579, 83}</string>
-				<string key="NSClassName">NSView</string>
-			</object>
-			<object class="NSMenu" id="410554753">
-				<string key="NSTitle"/>
-				<array class="NSMutableArray" key="NSMenuItems">
-					<object class="NSMenuItem" id="280923461">
-						<reference key="NSMenu" ref="410554753"/>
-						<string key="NSTitle">Rename</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="131625888">
-						<reference key="NSMenu" ref="410554753"/>
-						<string key="NSTitle">Remove</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="1022457675">
-						<reference key="NSMenu" ref="410554753"/>
-						<bool key="NSIsDisabled">YES</bool>
-						<bool key="NSIsSeparator">YES</bool>
-						<string key="NSTitle"/>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="1006081630">
-						<reference key="NSMenu" ref="410554753"/>
-						<string key="NSTitle">Duplicate</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="870584075">
-						<reference key="NSMenu" ref="410554753"/>
-						<string key="NSTitle">Make Default</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="601998920">
-						<reference key="NSMenu" ref="410554753"/>
-						<bool key="NSIsDisabled">YES</bool>
-						<bool key="NSIsSeparator">YES</bool>
-						<string key="NSTitle"/>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-					<object class="NSMenuItem" id="99515930">
-						<reference key="NSMenu" ref="410554753"/>
-						<string key="NSTitle">Export...</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="955092474"/>
-						<reference key="NSMixedImage" ref="913188683"/>
-					</object>
-				</array>
-			</object>
-			<object class="NSCustomView" id="507288218">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">268</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSTextField" id="300705398">
-						<reference key="NSNextResponder" ref="507288218"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{-3, 12}, {371, 34}}</string>
-						<reference key="NSSuperview" ref="507288218"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="485439419">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">138412032</int>
-							<string key="NSContents">For security reasons, your connection favorite passwords are not included in the export.</string>
-							<reference key="NSSupport" ref="807120225"/>
-							<reference key="NSControlView" ref="300705398"/>
-							<reference key="NSBackgroundColor" ref="644242225"/>
-							<reference key="NSTextColor" ref="434026568"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-				</array>
-				<string key="NSFrameSize">{365, 52}</string>
-				<string key="NSClassName">NSView</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<bool key="usesAutoincrementingIDs">NO</bool>
-			<array key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">errorDetailWindow</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="958272936"/>
-					</object>
-					<string key="id">5438</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshKeyLocationHelp</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="567906875"/>
-					</object>
-					<string key="id">5579</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectionDetailsScrollView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1058735001"/>
-					</object>
-					<string key="id">5592</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslKeyFileLocationHelp</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="12066713"/>
-					</object>
-					<string key="id">5671</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslCACertLocationHelp</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="3577372"/>
-					</object>
-					<string key="id">5686</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslCertificateLocationHelp</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="136328549"/>
-					</object>
-					<string key="id">5687</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectionView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="733821228"/>
-					</object>
-					<string key="id">5740</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectionSplitView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="616749187"/>
-					</object>
-					<string key="id">5745</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateKeyLocationFileVisibility:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="912885202"/>
-					</object>
-					<string key="id">5755</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateKeyLocationFileVisibility:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="388256324"/>
-					</object>
-					<string key="id">5759</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateKeyLocationFileVisibility:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="103272364"/>
-					</object>
-					<string key="id">5763</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateKeyLocationFileVisibility:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="455655503"/>
-					</object>
-					<string key="id">5767</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">exportPanelAccessoryView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="507288218"/>
-					</object>
-					<string key="id">5799</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectionInstructionsTextField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="570492783"/>
-					</object>
-					<string key="id">5800</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">removeNode:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="131625888"/>
-					</object>
-					<string key="id">5802</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">duplicateFavorite:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1006081630"/>
-					</object>
-					<string key="id">5803</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">makeSelectedFavoriteDefault:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="870584075"/>
-					</object>
-					<string key="id">5804</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">exportFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="99515930"/>
-					</object>
-					<string key="id">5805</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">renameNode:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="280923461"/>
-					</object>
-					<string key="id">5819</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">exportFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="567127977"/>
-					</object>
-					<string key="id">5844</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="914367302"/>
-					</object>
-					<string key="id">5845</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="233015422"/>
-					</object>
-					<string key="id">5846</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="703530048"/>
-					</object>
-					<string key="id">5847</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">reverseSortFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="216636539"/>
-					</object>
-					<string key="id">5848</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">importFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="217054518"/>
-					</object>
-					<string key="id">5849</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">favoritesSortByMenuItem</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="788191870"/>
-					</object>
-					<string key="id">5850</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">addGroup:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="29465158"/>
-					</object>
-					<string key="id">5856</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">addFavorite:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="973361787"/>
-					</object>
-					<string key="id">5857</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">duplicateFavorite:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="78866147"/>
-					</object>
-					<string key="id">5888</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">makeSelectedFavoriteDefault:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="505774202"/>
-					</object>
-					<string key="id">5889</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">renameNode:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="755096979"/>
-					</object>
-					<string key="id">5890</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">removeNode:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="645814925"/>
-					</object>
-					<string key="id">5891</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">errorDetailText</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="59706192"/>
-					</object>
-					<string key="id">5437</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">favoritesOutlineView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1012579052"/>
-					</object>
-					<string key="id">5768</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="586011242"/>
-					</object>
-					<string key="id">5662</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectionResizeContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="735564334"/>
-					</object>
-					<string key="id">5164</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketConnectionFormContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="394302879"/>
-					</object>
-					<string key="id">5163</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshUserField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="68541783"/>
-					</object>
-					<string key="id">5808</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketSSLCertificateButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="988136593"/>
-					</object>
-					<string key="id">5726</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardSSLCACertButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="839299955"/>
-					</object>
-					<string key="id">5667</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketUserField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="68541783"/>
-					</object>
-					<string key="id">5807</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketPasswordField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="512253301"/>
-					</object>
-					<string key="id">5428</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshPasswordField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="187191991"/>
-					</object>
-					<string key="id">5429</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateSSLInterface:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="16421625"/>
-					</object>
-					<string key="id">5723</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardSQLHostField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="644973446"/>
-					</object>
-					<string key="id">5446</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">saveFavorite:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="148626614"/>
-					</object>
-					<string key="id">5880</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardConnectionSSLDetailsContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="31135925"/>
-					</object>
-					<string key="id">5620</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">connectButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="460592307"/>
-					</object>
-					<string key="id">5444</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardUserField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="978463433"/>
-					</object>
-					<string key="id">5811</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketSSLCACertButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="680939705"/>
-					</object>
-					<string key="id">5725</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketNameField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="474825058"/>
-					</object>
-					<string key="id">5806</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">saveFavoriteButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="148626614"/>
-					</object>
-					<string key="id">5874</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="839299955"/>
-					</object>
-					<string key="id">5664</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshConnectionFormContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="326102394"/>
-					</object>
-					<string key="id">5167</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketConnectionSSLDetailsContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="866600720"/>
-					</object>
-					<string key="id">5724</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="680939705"/>
-					</object>
-					<string key="id">5718</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">addFavoriteUsingCurrentDetails:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="463178943"/>
-					</object>
-					<string key="id">5871</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshSSHKeyButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="183948302"/>
-					</object>
-					<string key="id">5494</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="988136593"/>
-					</object>
-					<string key="id">5719</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshSSHPasswordField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="21480939"/>
-					</object>
-					<string key="id">5430</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">initiateConnection:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="941479834"/>
-					</object>
-					<string key="id">5881</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardNameField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="810791200"/>
-					</object>
-					<string key="id">5810</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressIndicatorText</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="549907703"/>
-					</object>
-					<string key="id">5425</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshColorField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="941551595"/>
-					</object>
-					<string key="id">5899</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">editButtonsView</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="765073663"/>
-					</object>
-					<string key="id">5882</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardSSLKeyFileButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="586011242"/>
-					</object>
-					<string key="id">5665</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardSSLCertificateButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="945929172"/>
-					</object>
-					<string key="id">5666</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="183948302"/>
-					</object>
-					<string key="id">5661</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showHelp:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="990947983"/>
-					</object>
-					<string key="id">5351</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardColorField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="134580562"/>
-					</object>
-					<string key="id">5895</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateSSLInterface:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="508687946"/>
-					</object>
-					<string key="id">5651</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshSQLHostField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1030226140"/>
-					</object>
-					<string key="id">5445</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="945929172"/>
-					</object>
-					<string key="id">5663</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardPasswordField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="211629203"/>
-					</object>
-					<string key="id">5427</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketColorField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="247616432"/>
-					</object>
-					<string key="id">5897</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="237955939"/>
-					</object>
-					<string key="id">5717</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">testConnectButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="941479834"/>
-					</object>
-					<string key="id">5875</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressIndicator</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="575228526"/>
-					</object>
-					<string key="id">5426</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">helpButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="990947983"/>
-					</object>
-					<string key="id">5458</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">initiateConnection:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="460592307"/>
-					</object>
-					<string key="id">5439</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">standardConnectionFormContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="233374444"/>
-					</object>
-					<string key="id">5161</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshNameField</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1022082829"/>
-					</object>
-					<string key="id">5893</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="142713239"/>
-					</object>
-					<string key="id">Cyu-po-GQE</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="666556728"/>
-					</object>
-					<string key="id">cQ2-mu-0Ph</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">updateSSLInterface:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="1003668465"/>
-					</object>
-					<string key="id">KEh-s5-TWL</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sshConnectionSSLDetailsContainer</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="709218819"/>
-					</object>
-					<string key="id">K8K-hl-nke</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">chooseKeyLocation:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="165705421"/>
-					</object>
-					<string key="id">zge-vf-RDs</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslOverSSHKeyFileButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="165705421"/>
-					</object>
-					<string key="id">VTR-AE-QPt</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslOverSSHCertificateButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="142713239"/>
-					</object>
-					<string key="id">Ync-fQ-3aq</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sslOverSSHCACertButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="666556728"/>
-					</object>
-					<string key="id">1Wh-DE-z2l</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">socketSSLKeyFileButton</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="237955939"/>
-					</object>
-					<string key="id">nQE-St-ai8</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortFavorites:</string>
-						<reference key="source" ref="545410097"/>
-						<reference key="destination" ref="660097916"/>
-					</object>
-					<string key="id">Q9D-q1-jts</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1012579052"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">4930</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">menu</string>
-						<reference key="source" ref="1012579052"/>
-						<reference key="destination" ref="410554753"/>
-					</object>
-					<string key="id">5812</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="1012579052"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5341</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="1012579052"/>
-						<reference key="destination" ref="134031646"/>
-					</object>
-					<string key="id">5466</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: type</string>
-						<reference key="source" ref="134031646"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="134031646"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">selectedIndex: type</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">type</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">4992</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="134031646"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5165</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="644973446"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5358</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: host</string>
-						<reference key="source" ref="644973446"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="644973446"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: host</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">host</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<boolean value="YES" key="NSValidatesImmediately"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5195</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="978463433"/>
-						<reference key="destination" ref="211629203"/>
-					</object>
-					<string key="id">5464</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="978463433"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5359</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: user</string>
-						<reference key="source" ref="978463433"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="978463433"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: user</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">user</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5199</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: password</string>
-						<reference key="source" ref="211629203"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="211629203"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: password</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">password</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5203</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="211629203"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5360</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: database</string>
-						<reference key="source" ref="950381827"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="950381827"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: database</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">database</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5417</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="950381827"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5361</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1013612483"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5362</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: port</string>
-						<reference key="source" ref="1013612483"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1013612483"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: port</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">port</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">3306</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5418</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="68541783"/>
-						<reference key="destination" ref="512253301"/>
-					</object>
-					<string key="id">5463</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="68541783"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5363</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: user</string>
-						<reference key="source" ref="68541783"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="68541783"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: user</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">user</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5231</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="512253301"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5364</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: password</string>
-						<reference key="source" ref="512253301"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="512253301"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: password</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">password</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5234</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: database</string>
-						<reference key="source" ref="58217156"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="58217156"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: database</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">database</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5413</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="58217156"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5365</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="728228957"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5366</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: socket</string>
-						<reference key="source" ref="728228957"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="728228957"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: socket</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">socket</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5415</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1030226140"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5367</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: host</string>
-						<reference key="source" ref="1030226140"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1030226140"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: host</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">host</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5303</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="358903996"/>
-						<reference key="destination" ref="187191991"/>
-					</object>
-					<string key="id">5465</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: user</string>
-						<reference key="source" ref="358903996"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="358903996"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: user</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">user</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5307</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="358903996"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5368</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="187191991"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5369</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: password</string>
-						<reference key="source" ref="187191991"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="187191991"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: password</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">password</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5311</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: database</string>
-						<reference key="source" ref="1000646962"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1000646962"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: database</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">database</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5412</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1000646962"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5370</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1049720725"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5371</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: port</string>
-						<reference key="source" ref="1049720725"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1049720725"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: port</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">port</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">3306</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5419</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="844385120"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5372</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshHost</string>
-						<reference key="source" ref="844385120"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="844385120"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshHost</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshHost</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5323</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshUser</string>
-						<reference key="source" ref="790983747"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="790983747"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshUser</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshUser</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5327</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="790983747"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5373</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshPassword</string>
-						<reference key="source" ref="21480939"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="21480939"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshPassword</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshPassword</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5504</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: sshKeyLocationEnabled</string>
-						<reference key="source" ref="21480939"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="21480939"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: sshKeyLocationEnabled</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">sshKeyLocationEnabled</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5559</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="21480939"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5374</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: sshKeyLocationEnabled</string>
-						<reference key="source" ref="627782947"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="627782947"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: sshKeyLocationEnabled</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">sshKeyLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5549</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="692784990"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5375</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshPort</string>
-						<reference key="source" ref="692784990"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="692784990"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshPort</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshPort</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5737</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: name</string>
-						<reference key="source" ref="810791200"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="810791200"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: name</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">name</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5416</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="810791200"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5402</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="474825058"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5401</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: name</string>
-						<reference key="source" ref="474825058"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="474825058"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: name</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">name</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5400</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: name</string>
-						<reference key="source" ref="1022082829"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1022082829"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: name</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">name</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-								<string key="NSNullPlaceholder">optional</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5411</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1022082829"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5414</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="958272936"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5461</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="59706192"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5462</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshKeyLocationEnabled</string>
-						<reference key="source" ref="183948302"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="183948302"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshKeyLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshKeyLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5551</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sshKeyLocation</string>
-						<reference key="source" ref="180145997"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="180145997"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sshKeyLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sshKeyLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5570</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sshKeyLocation</string>
-						<reference key="source" ref="180145997"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="180145997"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sshKeyLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sshKeyLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSContinuouslyUpdatesValue</string>
-								<boolean value="YES" key="NS.object.0"/>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5563</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: sshKeyLocationEnabled</string>
-						<reference key="source" ref="180145997"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="180145997"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: sshKeyLocationEnabled</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">sshKeyLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="1" key="NSMultipleValuesPlaceholder"/>
-								<integer value="1" key="NSNoSelectionPlaceholder"/>
-								<integer value="1" key="NSNotApplicablePlaceholder"/>
-								<integer value="1" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">NSNegateBoolean</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5562</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: sshKeyLocationEnabled</string>
-						<reference key="source" ref="906103858"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="906103858"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: sshKeyLocationEnabled</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">sshKeyLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="1" key="NSMultipleValuesPlaceholder"/>
-								<integer value="1" key="NSNoSelectionPlaceholder"/>
-								<integer value="1" key="NSNotApplicablePlaceholder"/>
-								<integer value="1" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">NSNegateBoolean</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5561</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: useSSL</string>
-						<reference key="source" ref="508687946"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="508687946"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: useSSL</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5627</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: useSSL</string>
-						<reference key="source" ref="31135925"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="31135925"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: useSSL</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="1" key="NSMultipleValuesPlaceholder"/>
-								<integer value="1" key="NSNoSelectionPlaceholder"/>
-								<integer value="1" key="NSNotApplicablePlaceholder"/>
-								<integer value="1" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">NSNegateBoolean</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5649</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslKeyFileLocation</string>
-						<reference key="source" ref="679511995"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="679511995"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslKeyFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5641</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocation</string>
-						<reference key="source" ref="679511995"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="679511995"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5732</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocationEnabled</string>
-						<reference key="source" ref="586011242"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="586011242"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5673</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocationEnabled</string>
-						<reference key="source" ref="945929172"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="945929172"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5677</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCertificateFileLocation</string>
-						<reference key="source" ref="950540175"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="950540175"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCertificateFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5639</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocation</string>
-						<reference key="source" ref="950540175"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="950540175"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5731</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocationEnabled</string>
-						<reference key="source" ref="839299955"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="839299955"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5679</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCACertFileLocation</string>
-						<reference key="source" ref="638710413"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="638710413"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCACertFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5637</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocation</string>
-						<reference key="source" ref="638710413"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="638710413"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5730</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: useSSL</string>
-						<reference key="source" ref="866600720"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="866600720"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: useSSL</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="1" key="NSMultipleValuesPlaceholder"/>
-								<integer value="1" key="NSNoSelectionPlaceholder"/>
-								<integer value="1" key="NSNotApplicablePlaceholder"/>
-								<integer value="1" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">NSNegateBoolean</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5710</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocation</string>
-						<reference key="source" ref="484504415"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="484504415"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5734</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCACertFileLocation</string>
-						<reference key="source" ref="484504415"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="484504415"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCACertFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5712</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocationEnabled</string>
-						<reference key="source" ref="680939705"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="680939705"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5715</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCertificateFileLocation</string>
-						<reference key="source" ref="216069484"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="216069484"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCertificateFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5708</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocation</string>
-						<reference key="source" ref="216069484"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="216069484"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5735</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocationEnabled</string>
-						<reference key="source" ref="988136593"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="988136593"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5707</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocationEnabled</string>
-						<reference key="source" ref="237955939"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="237955939"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5711</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslKeyFileLocation</string>
-						<reference key="source" ref="51601157"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="51601157"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslKeyFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5714</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocation</string>
-						<reference key="source" ref="51601157"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="51601157"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5733</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: useSSL</string>
-						<reference key="source" ref="16421625"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="16421625"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: useSSL</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5722</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">additionalDragHandleView</string>
-						<reference key="source" ref="616749187"/>
-						<reference key="destination" ref="250765522"/>
-					</object>
-					<string key="id">5860</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="616749187"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5861</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.KeySelectionHiddenFilesVisibility</string>
-						<reference key="source" ref="912885202"/>
-						<reference key="destination" ref="642702582"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="912885202"/>
-							<reference key="NSDestination" ref="642702582"/>
-							<string key="NSLabel">value: values.KeySelectionHiddenFilesVisibility</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.KeySelectionHiddenFilesVisibility</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5754</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.KeySelectionHiddenFilesVisibility</string>
-						<reference key="source" ref="388256324"/>
-						<reference key="destination" ref="642702582"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="388256324"/>
-							<reference key="NSDestination" ref="642702582"/>
-							<string key="NSLabel">value: values.KeySelectionHiddenFilesVisibility</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.KeySelectionHiddenFilesVisibility</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5758</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.KeySelectionHiddenFilesVisibility</string>
-						<reference key="source" ref="103272364"/>
-						<reference key="destination" ref="642702582"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="103272364"/>
-							<reference key="NSDestination" ref="642702582"/>
-							<string key="NSLabel">value: values.KeySelectionHiddenFilesVisibility</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.KeySelectionHiddenFilesVisibility</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5762</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: values.KeySelectionHiddenFilesVisibility</string>
-						<reference key="source" ref="455655503"/>
-						<reference key="destination" ref="642702582"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="455655503"/>
-							<reference key="NSDestination" ref="642702582"/>
-							<string key="NSLabel">value: values.KeySelectionHiddenFilesVisibility</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">values.KeySelectionHiddenFilesVisibility</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">5766</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="410554753"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5818</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="134580562"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5900</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="247616432"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5901</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="941551595"/>
-						<reference key="destination" ref="545410097"/>
-					</object>
-					<string key="id">5902</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocation</string>
-						<reference key="source" ref="206891834"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="206891834"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">aQT-Hc-RZK</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCertificateFileLocation</string>
-						<reference key="source" ref="206891834"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="206891834"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCertificateFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCertificateFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">aUS-Id-i02</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocationEnabled</string>
-						<reference key="source" ref="666556728"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="666556728"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">SW6-dc-cub</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslCACertFileLocation</string>
-						<reference key="source" ref="258381978"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="258381978"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslCACertFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">s1j-iY-B0W</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCACertFileLocation</string>
-						<reference key="source" ref="258381978"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="258381978"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCACertFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCACertFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">bez-TY-JVB</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: useSSL</string>
-						<reference key="source" ref="709218819"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="709218819"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">hidden: useSSL</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="1" key="NSMultipleValuesPlaceholder"/>
-								<integer value="1" key="NSNoSelectionPlaceholder"/>
-								<integer value="1" key="NSNotApplicablePlaceholder"/>
-								<integer value="1" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">NSNegateBoolean</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">6oe-5y-dVM</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: useSSL</string>
-						<reference key="source" ref="1003668465"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1003668465"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: useSSL</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">useSSL</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">WuC-tH-Z8g</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslCertificateFileLocationEnabled</string>
-						<reference key="source" ref="142713239"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="142713239"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslCertificateFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslCertificateFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">Ccl-JC-0KZ</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">toolTip: sslKeyFileLocation</string>
-						<reference key="source" ref="436440005"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="436440005"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">toolTip: sslKeyFileLocation</string>
-							<string key="NSBinding">toolTip</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">1dY-ya-XZT</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocation</string>
-						<reference key="source" ref="436440005"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="436440005"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocation</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocation</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">none set</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">HxQ-8U-qCi</string>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: sslKeyFileLocationEnabled</string>
-						<reference key="source" ref="165705421"/>
-						<reference key="destination" ref="545410097"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="165705421"/>
-							<reference key="NSDestination" ref="545410097"/>
-							<string key="NSLabel">value: sslKeyFileLocationEnabled</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">sslKeyFileLocationEnabled</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSMultipleValuesPlaceholder"/>
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<string key="id">AQO-79-Qoa</string>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<string key="id">0</string>
-						<array key="object" id="0"/>
-						<reference key="children" ref="584594810"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">-1</string>
-						<reference key="object" ref="547391009"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">-2</string>
-						<reference key="object" ref="545410097"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">-3</string>
-						<reference key="object" ref="292263310"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5431</string>
-						<reference key="object" ref="958272936"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="536120400"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Error Detail HUD</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5432</string>
-						<reference key="object" ref="536120400"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="699163511"/>
-						</array>
-						<reference key="parent" ref="958272936"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5433</string>
-						<reference key="object" ref="699163511"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="266224177"/>
-							<reference ref="79422493"/>
-							<reference ref="59706192"/>
-						</array>
-						<reference key="parent" ref="536120400"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5435</string>
-						<reference key="object" ref="266224177"/>
-						<reference key="parent" ref="699163511"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5436</string>
-						<reference key="object" ref="79422493"/>
-						<reference key="parent" ref="699163511"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5455</string>
-						<reference key="object" ref="642702582"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5576</string>
-						<reference key="object" ref="567906875"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="44241774"/>
-							<reference ref="912885202"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">SSH Key Selection Help</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5577</string>
-						<reference key="object" ref="44241774"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1045018411"/>
-						</array>
-						<reference key="parent" ref="567906875"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5578</string>
-						<reference key="object" ref="1045018411"/>
-						<reference key="parent" ref="44241774"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5668</string>
-						<reference key="object" ref="12066713"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="538839943"/>
-							<reference ref="388256324"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">SSL Key File Selection Help</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5669</string>
-						<reference key="object" ref="538839943"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="124352014"/>
-						</array>
-						<reference key="parent" ref="12066713"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5670</string>
-						<reference key="object" ref="124352014"/>
-						<reference key="parent" ref="538839943"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5680</string>
-						<reference key="object" ref="3577372"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="761812578"/>
-							<reference ref="455655503"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">SSL CA Cert File Selection Help</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5681</string>
-						<reference key="object" ref="761812578"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="444474564"/>
-						</array>
-						<reference key="parent" ref="3577372"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5682</string>
-						<reference key="object" ref="444474564"/>
-						<reference key="parent" ref="761812578"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5683</string>
-						<reference key="object" ref="136328549"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="802544195"/>
-							<reference ref="103272364"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">SSL Certificate File Selection Help</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5684</string>
-						<reference key="object" ref="802544195"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="196059550"/>
-						</array>
-						<reference key="parent" ref="136328549"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5685</string>
-						<reference key="object" ref="196059550"/>
-						<reference key="parent" ref="802544195"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5739</string>
-						<reference key="object" ref="733821228"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="616749187"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">ConnectionView</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5741</string>
-						<reference key="object" ref="616749187"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="551584428"/>
-							<reference ref="563806501"/>
-						</array>
-						<reference key="parent" ref="733821228"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5742</string>
-						<reference key="object" ref="551584428"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="524598165"/>
-							<reference ref="589005585"/>
-							<reference ref="735633081"/>
-							<reference ref="29465158"/>
-							<reference ref="973361787"/>
-							<reference ref="250765522"/>
-						</array>
-						<reference key="parent" ref="616749187"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5743</string>
-						<reference key="object" ref="563806501"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="570492783"/>
-							<reference ref="1058735001"/>
-						</array>
-						<reference key="parent" ref="616749187"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4910</string>
-						<reference key="object" ref="524598165"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="802793151"/>
-							<reference ref="533108700"/>
-							<reference ref="1012579052"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4912</string>
-						<reference key="object" ref="802793151"/>
-						<reference key="parent" ref="524598165"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4911</string>
-						<reference key="object" ref="533108700"/>
-						<reference key="parent" ref="524598165"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5154</string>
-						<reference key="object" ref="570492783"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="607446274"/>
-						</array>
-						<reference key="parent" ref="563806501"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5155</string>
-						<reference key="object" ref="607446274"/>
-						<reference key="parent" ref="570492783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5588</string>
-						<reference key="object" ref="1058735001"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="508899576"/>
-							<reference ref="108277656"/>
-							<reference ref="315390047"/>
-						</array>
-						<reference key="parent" ref="563806501"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5589</string>
-						<reference key="object" ref="508899576"/>
-						<reference key="parent" ref="1058735001"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5590</string>
-						<reference key="object" ref="108277656"/>
-						<reference key="parent" ref="1058735001"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5748</string>
-						<reference key="object" ref="912885202"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="388136120"/>
-						</array>
-						<reference key="parent" ref="567906875"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5749</string>
-						<reference key="object" ref="388136120"/>
-						<reference key="parent" ref="912885202"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5756</string>
-						<reference key="object" ref="388256324"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="844788897"/>
-						</array>
-						<reference key="parent" ref="12066713"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5757</string>
-						<reference key="object" ref="844788897"/>
-						<reference key="parent" ref="388256324"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5760</string>
-						<reference key="object" ref="103272364"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="20247014"/>
-						</array>
-						<reference key="parent" ref="136328549"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5761</string>
-						<reference key="object" ref="20247014"/>
-						<reference key="parent" ref="103272364"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5764</string>
-						<reference key="object" ref="455655503"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="609741956"/>
-						</array>
-						<reference key="parent" ref="3577372"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5765</string>
-						<reference key="object" ref="609741956"/>
-						<reference key="parent" ref="455655503"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5788</string>
-						<reference key="object" ref="410554753"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1006081630"/>
-							<reference ref="870584075"/>
-							<reference ref="1022457675"/>
-							<reference ref="99515930"/>
-							<reference ref="601998920"/>
-							<reference ref="131625888"/>
-							<reference ref="280923461"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Context Menu</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5789</string>
-						<reference key="object" ref="1006081630"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5790</string>
-						<reference key="object" ref="870584075"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5791</string>
-						<reference key="object" ref="1022457675"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5792</string>
-						<reference key="object" ref="99515930"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5793</string>
-						<reference key="object" ref="601998920"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5794</string>
-						<reference key="object" ref="131625888"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5795</string>
-						<reference key="object" ref="280923461"/>
-						<reference key="parent" ref="410554753"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5796</string>
-						<reference key="object" ref="507288218"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="300705398"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">AccessoryView</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5797</string>
-						<reference key="object" ref="300705398"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="485439419"/>
-						</array>
-						<reference key="parent" ref="507288218"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5798</string>
-						<reference key="object" ref="485439419"/>
-						<reference key="parent" ref="300705398"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5822</string>
-						<reference key="object" ref="589005585"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="147458525"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5823</string>
-						<reference key="object" ref="147458525"/>
-						<reference key="parent" ref="589005585"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5824</string>
-						<reference key="object" ref="735633081"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="970960222"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5825</string>
-						<reference key="object" ref="970960222"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="167853330"/>
-						</array>
-						<reference key="parent" ref="735633081"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5826</string>
-						<reference key="object" ref="167853330"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="797961582"/>
-							<reference ref="217054518"/>
-							<reference ref="567127977"/>
-							<reference ref="214273320"/>
-							<reference ref="788191870"/>
-							<reference ref="755096979"/>
-							<reference ref="645814925"/>
-							<reference ref="612600535"/>
-							<reference ref="78866147"/>
-							<reference ref="1068847855"/>
-							<reference ref="505774202"/>
-						</array>
-						<reference key="parent" ref="970960222"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5833</string>
-						<reference key="object" ref="797961582"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5834</string>
-						<reference key="object" ref="217054518"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5835</string>
-						<reference key="object" ref="567127977"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5836</string>
-						<reference key="object" ref="214273320"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5837</string>
-						<reference key="object" ref="788191870"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="642202204"/>
-						</array>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5838</string>
-						<reference key="object" ref="642202204"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="216636539"/>
-							<reference ref="975459050"/>
-							<reference ref="914367302"/>
-							<reference ref="703530048"/>
-							<reference ref="233015422"/>
-							<reference ref="660097916"/>
-						</array>
-						<reference key="parent" ref="788191870"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5839</string>
-						<reference key="object" ref="216636539"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5840</string>
-						<reference key="object" ref="975459050"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5841</string>
-						<reference key="object" ref="914367302"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5842</string>
-						<reference key="object" ref="703530048"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5843</string>
-						<reference key="object" ref="233015422"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5851</string>
-						<reference key="object" ref="29465158"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="340161940"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5852</string>
-						<reference key="object" ref="340161940"/>
-						<reference key="parent" ref="29465158"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5853</string>
-						<reference key="object" ref="973361787"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="953363291"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5854</string>
-						<reference key="object" ref="953363291"/>
-						<reference key="parent" ref="973361787"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5858</string>
-						<reference key="object" ref="250765522"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="875077014"/>
-						</array>
-						<reference key="parent" ref="551584428"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5859</string>
-						<reference key="object" ref="875077014"/>
-						<reference key="parent" ref="250765522"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5883</string>
-						<reference key="object" ref="755096979"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5884</string>
-						<reference key="object" ref="645814925"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5885</string>
-						<reference key="object" ref="612600535"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5886</string>
-						<reference key="object" ref="78866147"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5887</string>
-						<reference key="object" ref="505774202"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5892</string>
-						<reference key="object" ref="1068847855"/>
-						<reference key="parent" ref="167853330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5434</string>
-						<reference key="object" ref="59706192"/>
-						<reference key="parent" ref="699163511"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4913</string>
-						<reference key="object" ref="1012579052"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="131458815"/>
-						</array>
-						<reference key="parent" ref="524598165"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4915</string>
-						<reference key="object" ref="131458815"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="93569184"/>
-						</array>
-						<reference key="parent" ref="1012579052"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4918</string>
-						<reference key="object" ref="93569184"/>
-						<reference key="parent" ref="131458815"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5447</string>
-						<reference key="object" ref="315390047"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="735564334"/>
-						</array>
-						<reference key="parent" ref="1058735001"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4888</string>
-						<reference key="object" ref="735564334"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="134031646"/>
-							<reference ref="575228526"/>
-							<reference ref="549907703"/>
-							<reference ref="990947983"/>
-							<reference ref="460592307"/>
-							<reference ref="765073663"/>
-						</array>
-						<reference key="parent" ref="315390047"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5862</string>
-						<reference key="object" ref="765073663"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="463178943"/>
-							<reference ref="941479834"/>
-							<reference ref="148626614"/>
-						</array>
-						<reference key="parent" ref="735564334"/>
-						<string key="objectName">Edit Connection Buttons Box</string>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5863</string>
-						<reference key="object" ref="941479834"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="90221493"/>
-						</array>
-						<reference key="parent" ref="765073663"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5864</string>
-						<reference key="object" ref="90221493"/>
-						<reference key="parent" ref="941479834"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5865</string>
-						<reference key="object" ref="463178943"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1027746126"/>
-						</array>
-						<reference key="parent" ref="765073663"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5866</string>
-						<reference key="object" ref="1027746126"/>
-						<reference key="parent" ref="463178943"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5869</string>
-						<reference key="object" ref="148626614"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1020482049"/>
-						</array>
-						<reference key="parent" ref="765073663"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5870</string>
-						<reference key="object" ref="1020482049"/>
-						<reference key="parent" ref="148626614"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5157</string>
-						<reference key="object" ref="460592307"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="424756162"/>
-						</array>
-						<reference key="parent" ref="735564334"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5158</string>
-						<reference key="object" ref="424756162"/>
-						<reference key="parent" ref="460592307"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4829</string>
-						<reference key="object" ref="990947983"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="757039715"/>
-						</array>
-						<reference key="parent" ref="735564334"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4839</string>
-						<reference key="object" ref="757039715"/>
-						<reference key="parent" ref="990947983"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5423</string>
-						<reference key="object" ref="549907703"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="321846713"/>
-						</array>
-						<reference key="parent" ref="735564334"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5424</string>
-						<reference key="object" ref="321846713"/>
-						<reference key="parent" ref="549907703"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5422</string>
-						<reference key="object" ref="575228526"/>
-						<reference key="parent" ref="735564334"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4980</string>
-						<reference key="object" ref="134031646"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="591192172"/>
-							<reference ref="517771995"/>
-							<reference ref="253369045"/>
-						</array>
-						<reference key="parent" ref="735564334"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4981</string>
-						<reference key="object" ref="253369045"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="32802602"/>
-						</array>
-						<reference key="parent" ref="134031646"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4984</string>
-						<reference key="object" ref="32802602"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="233374444"/>
-							<reference ref="31135925"/>
-						</array>
-						<reference key="parent" ref="253369045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5595</string>
-						<reference key="object" ref="31135925"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="104955330"/>
-							<reference ref="638710413"/>
-							<reference ref="684819179"/>
-							<reference ref="950540175"/>
-							<reference ref="1034069158"/>
-							<reference ref="586011242"/>
-							<reference ref="945929172"/>
-							<reference ref="839299955"/>
-							<reference ref="679511995"/>
-						</array>
-						<reference key="parent" ref="32802602"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5596</string>
-						<reference key="object" ref="679511995"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="650760201"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5597</string>
-						<reference key="object" ref="650760201"/>
-						<reference key="parent" ref="679511995"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5612</string>
-						<reference key="object" ref="839299955"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1013426677"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5617</string>
-						<reference key="object" ref="1013426677"/>
-						<reference key="parent" ref="839299955"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5604</string>
-						<reference key="object" ref="945929172"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1000000271"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5609</string>
-						<reference key="object" ref="1000000271"/>
-						<reference key="parent" ref="945929172"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5600</string>
-						<reference key="object" ref="586011242"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="85329089"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5601</string>
-						<reference key="object" ref="85329089"/>
-						<reference key="parent" ref="586011242"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5598</string>
-						<reference key="object" ref="1034069158"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="943522732"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5599</string>
-						<reference key="object" ref="943522732"/>
-						<reference key="parent" ref="1034069158"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5605</string>
-						<reference key="object" ref="950540175"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="196185392"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5608</string>
-						<reference key="object" ref="196185392"/>
-						<reference key="parent" ref="950540175"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5606</string>
-						<reference key="object" ref="684819179"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="371333119"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5607</string>
-						<reference key="object" ref="371333119"/>
-						<reference key="parent" ref="684819179"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5613</string>
-						<reference key="object" ref="638710413"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="791857368"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5616</string>
-						<reference key="object" ref="791857368"/>
-						<reference key="parent" ref="638710413"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5614</string>
-						<reference key="object" ref="104955330"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="69612386"/>
-						</array>
-						<reference key="parent" ref="31135925"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5615</string>
-						<reference key="object" ref="69612386"/>
-						<reference key="parent" ref="104955330"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5156</string>
-						<reference key="object" ref="233374444"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="810791200"/>
-							<reference ref="445567924"/>
-							<reference ref="134580562"/>
-							<reference ref="910543023"/>
-							<reference ref="1013612483"/>
-							<reference ref="788113046"/>
-							<reference ref="950381827"/>
-							<reference ref="105635377"/>
-							<reference ref="211629203"/>
-							<reference ref="987440606"/>
-							<reference ref="978463433"/>
-							<reference ref="786098118"/>
-							<reference ref="644973446"/>
-							<reference ref="508687946"/>
-						</array>
-						<reference key="parent" ref="32802602"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5593</string>
-						<reference key="object" ref="508687946"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="184523755"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5594</string>
-						<reference key="object" ref="184523755"/>
-						<reference key="parent" ref="508687946"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5171</string>
-						<reference key="object" ref="644973446"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="859982751"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5172</string>
-						<reference key="object" ref="859982751"/>
-						<reference key="parent" ref="644973446"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5173</string>
-						<reference key="object" ref="786098118"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="393023945"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5174</string>
-						<reference key="object" ref="393023945"/>
-						<reference key="parent" ref="786098118"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5175</string>
-						<reference key="object" ref="978463433"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="925313159"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5178</string>
-						<reference key="object" ref="925313159"/>
-						<reference key="parent" ref="978463433"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5176</string>
-						<reference key="object" ref="987440606"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="377431100"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5177</string>
-						<reference key="object" ref="377431100"/>
-						<reference key="parent" ref="987440606"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5179</string>
-						<reference key="object" ref="211629203"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="646391991"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5182</string>
-						<reference key="object" ref="646391991"/>
-						<reference key="parent" ref="211629203"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5180</string>
-						<reference key="object" ref="105635377"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="785119002"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5181</string>
-						<reference key="object" ref="785119002"/>
-						<reference key="parent" ref="105635377"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5183</string>
-						<reference key="object" ref="950381827"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="925102591"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5186</string>
-						<reference key="object" ref="925102591"/>
-						<reference key="parent" ref="950381827"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5184</string>
-						<reference key="object" ref="788113046"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="441978581"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5185</string>
-						<reference key="object" ref="441978581"/>
-						<reference key="parent" ref="788113046"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5187</string>
-						<reference key="object" ref="1013612483"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1003825843"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5190</string>
-						<reference key="object" ref="1003825843"/>
-						<reference key="parent" ref="1013612483"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5188</string>
-						<reference key="object" ref="910543023"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="588889019"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5189</string>
-						<reference key="object" ref="588889019"/>
-						<reference key="parent" ref="910543023"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5894</string>
-						<reference key="object" ref="134580562"/>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5377</string>
-						<reference key="object" ref="445567924"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="485990188"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5378</string>
-						<reference key="object" ref="485990188"/>
-						<reference key="parent" ref="445567924"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5376</string>
-						<reference key="object" ref="810791200"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1040289660"/>
-						</array>
-						<reference key="parent" ref="233374444"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5379</string>
-						<reference key="object" ref="1040289660"/>
-						<reference key="parent" ref="810791200"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4982</string>
-						<reference key="object" ref="517771995"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="962671066"/>
-						</array>
-						<reference key="parent" ref="134031646"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4983</string>
-						<reference key="object" ref="962671066"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="394302879"/>
-							<reference ref="866600720"/>
-						</array>
-						<reference key="parent" ref="517771995"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5688</string>
-						<reference key="object" ref="866600720"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="680939705"/>
-							<reference ref="988136593"/>
-							<reference ref="237955939"/>
-							<reference ref="98826968"/>
-							<reference ref="484504415"/>
-							<reference ref="521125104"/>
-							<reference ref="216069484"/>
-							<reference ref="57862599"/>
-							<reference ref="51601157"/>
-						</array>
-						<reference key="parent" ref="962671066"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5697</string>
-						<reference key="object" ref="51601157"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="575863174"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5698</string>
-						<reference key="object" ref="575863174"/>
-						<reference key="parent" ref="51601157"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5696</string>
-						<reference key="object" ref="57862599"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="357553281"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5699</string>
-						<reference key="object" ref="357553281"/>
-						<reference key="parent" ref="57862599"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5693</string>
-						<reference key="object" ref="216069484"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="276609847"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5702</string>
-						<reference key="object" ref="276609847"/>
-						<reference key="parent" ref="216069484"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5692</string>
-						<reference key="object" ref="521125104"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1025158673"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5703</string>
-						<reference key="object" ref="1025158673"/>
-						<reference key="parent" ref="521125104"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5690</string>
-						<reference key="object" ref="484504415"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="169093017"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5705</string>
-						<reference key="object" ref="169093017"/>
-						<reference key="parent" ref="484504415"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5689</string>
-						<reference key="object" ref="98826968"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="730590428"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5706</string>
-						<reference key="object" ref="730590428"/>
-						<reference key="parent" ref="98826968"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5695</string>
-						<reference key="object" ref="237955939"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="167444868"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5700</string>
-						<reference key="object" ref="167444868"/>
-						<reference key="parent" ref="237955939"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5694</string>
-						<reference key="object" ref="988136593"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="559442548"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5701</string>
-						<reference key="object" ref="559442548"/>
-						<reference key="parent" ref="988136593"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5691</string>
-						<reference key="object" ref="680939705"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="308087760"/>
-						</array>
-						<reference key="parent" ref="866600720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5704</string>
-						<reference key="object" ref="308087760"/>
-						<reference key="parent" ref="680939705"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5162</string>
-						<reference key="object" ref="394302879"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="474825058"/>
-							<reference ref="459734357"/>
-							<reference ref="247616432"/>
-							<reference ref="591324856"/>
-							<reference ref="728228957"/>
-							<reference ref="745773732"/>
-							<reference ref="58217156"/>
-							<reference ref="789391730"/>
-							<reference ref="512253301"/>
-							<reference ref="607362814"/>
-							<reference ref="68541783"/>
-							<reference ref="16421625"/>
-						</array>
-						<reference key="parent" ref="962671066"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5720</string>
-						<reference key="object" ref="16421625"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="972347112"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5721</string>
-						<reference key="object" ref="972347112"/>
-						<reference key="parent" ref="16421625"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5212</string>
-						<reference key="object" ref="68541783"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="279442436"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5227</string>
-						<reference key="object" ref="279442436"/>
-						<reference key="parent" ref="68541783"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5213</string>
-						<reference key="object" ref="607362814"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="798396187"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5226</string>
-						<reference key="object" ref="798396187"/>
-						<reference key="parent" ref="607362814"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5214</string>
-						<reference key="object" ref="512253301"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="251554254"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5225</string>
-						<reference key="object" ref="251554254"/>
-						<reference key="parent" ref="512253301"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5215</string>
-						<reference key="object" ref="789391730"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="797213431"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5224</string>
-						<reference key="object" ref="797213431"/>
-						<reference key="parent" ref="789391730"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5216</string>
-						<reference key="object" ref="58217156"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="185246669"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5223</string>
-						<reference key="object" ref="185246669"/>
-						<reference key="parent" ref="58217156"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5217</string>
-						<reference key="object" ref="745773732"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="728524936"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5222</string>
-						<reference key="object" ref="728524936"/>
-						<reference key="parent" ref="745773732"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5218</string>
-						<reference key="object" ref="728228957"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="299457759"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5221</string>
-						<reference key="object" ref="299457759"/>
-						<reference key="parent" ref="728228957"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5219</string>
-						<reference key="object" ref="591324856"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="317867885"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5220</string>
-						<reference key="object" ref="317867885"/>
-						<reference key="parent" ref="591324856"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5896</string>
-						<reference key="object" ref="247616432"/>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5386</string>
-						<reference key="object" ref="459734357"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="352725628"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5387</string>
-						<reference key="object" ref="352725628"/>
-						<reference key="parent" ref="459734357"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5385</string>
-						<reference key="object" ref="474825058"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="684614893"/>
-						</array>
-						<reference key="parent" ref="394302879"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5388</string>
-						<reference key="object" ref="684614893"/>
-						<reference key="parent" ref="474825058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4985</string>
-						<reference key="object" ref="591192172"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="159800861"/>
-						</array>
-						<reference key="parent" ref="134031646"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">4986</string>
-						<reference key="object" ref="159800861"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="709218819"/>
-							<reference ref="326102394"/>
-						</array>
-						<reference key="parent" ref="591192172"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5166</string>
-						<reference key="object" ref="326102394"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1022082829"/>
-							<reference ref="761323775"/>
-							<reference ref="941551595"/>
-							<reference ref="183948302"/>
-							<reference ref="984151006"/>
-							<reference ref="692784990"/>
-							<reference ref="627782947"/>
-							<reference ref="21480939"/>
-							<reference ref="558754343"/>
-							<reference ref="790983747"/>
-							<reference ref="81612279"/>
-							<reference ref="844385120"/>
-							<reference ref="914345743"/>
-							<reference ref="1049720725"/>
-							<reference ref="632758915"/>
-							<reference ref="1000646962"/>
-							<reference ref="71258292"/>
-							<reference ref="187191991"/>
-							<reference ref="189856761"/>
-							<reference ref="358903996"/>
-							<reference ref="615962367"/>
-							<reference ref="1030226140"/>
-							<reference ref="180145997"/>
-							<reference ref="906103858"/>
-							<reference ref="1003668465"/>
-						</array>
-						<reference key="parent" ref="159800861"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5525</string>
-						<reference key="object" ref="906103858"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="882604644"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5526</string>
-						<reference key="object" ref="882604644"/>
-						<reference key="parent" ref="906103858"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5523</string>
-						<reference key="object" ref="180145997"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="13940444"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5524</string>
-						<reference key="object" ref="13940444"/>
-						<reference key="parent" ref="180145997"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5264</string>
-						<reference key="object" ref="1030226140"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="933547668"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5283</string>
-						<reference key="object" ref="933547668"/>
-						<reference key="parent" ref="1030226140"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5265</string>
-						<reference key="object" ref="615962367"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="547674489"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5282</string>
-						<reference key="object" ref="547674489"/>
-						<reference key="parent" ref="615962367"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5266</string>
-						<reference key="object" ref="358903996"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="869330413"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5281</string>
-						<reference key="object" ref="869330413"/>
-						<reference key="parent" ref="358903996"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5267</string>
-						<reference key="object" ref="189856761"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="218707841"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5280</string>
-						<reference key="object" ref="218707841"/>
-						<reference key="parent" ref="189856761"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5268</string>
-						<reference key="object" ref="187191991"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="737530250"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5279</string>
-						<reference key="object" ref="737530250"/>
-						<reference key="parent" ref="187191991"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5269</string>
-						<reference key="object" ref="71258292"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1056521404"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5278</string>
-						<reference key="object" ref="1056521404"/>
-						<reference key="parent" ref="71258292"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5270</string>
-						<reference key="object" ref="1000646962"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="289965133"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5277</string>
-						<reference key="object" ref="289965133"/>
-						<reference key="parent" ref="1000646962"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5271</string>
-						<reference key="object" ref="632758915"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="664433389"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5276</string>
-						<reference key="object" ref="664433389"/>
-						<reference key="parent" ref="632758915"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5272</string>
-						<reference key="object" ref="1049720725"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="615536496"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5275</string>
-						<reference key="object" ref="615536496"/>
-						<reference key="parent" ref="1049720725"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5273</string>
-						<reference key="object" ref="914345743"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="265944034"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5274</string>
-						<reference key="object" ref="265944034"/>
-						<reference key="parent" ref="914345743"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5284</string>
-						<reference key="object" ref="844385120"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="505035309"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5299</string>
-						<reference key="object" ref="505035309"/>
-						<reference key="parent" ref="844385120"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5285</string>
-						<reference key="object" ref="81612279"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="386177793"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5298</string>
-						<reference key="object" ref="386177793"/>
-						<reference key="parent" ref="81612279"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5286</string>
-						<reference key="object" ref="790983747"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="347555313"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5297</string>
-						<reference key="object" ref="347555313"/>
-						<reference key="parent" ref="790983747"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5287</string>
-						<reference key="object" ref="558754343"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="222275233"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5296</string>
-						<reference key="object" ref="222275233"/>
-						<reference key="parent" ref="558754343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5288</string>
-						<reference key="object" ref="21480939"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="944931136"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5295</string>
-						<reference key="object" ref="944931136"/>
-						<reference key="parent" ref="21480939"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5289</string>
-						<reference key="object" ref="627782947"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="369035253"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5294</string>
-						<reference key="object" ref="369035253"/>
-						<reference key="parent" ref="627782947"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5290</string>
-						<reference key="object" ref="692784990"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="850057181"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5293</string>
-						<reference key="object" ref="850057181"/>
-						<reference key="parent" ref="692784990"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5291</string>
-						<reference key="object" ref="984151006"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="563972303"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5292</string>
-						<reference key="object" ref="563972303"/>
-						<reference key="parent" ref="984151006"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5492</string>
-						<reference key="object" ref="183948302"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="510891456"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5493</string>
-						<reference key="object" ref="510891456"/>
-						<reference key="parent" ref="183948302"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5898</string>
-						<reference key="object" ref="941551595"/>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5404</string>
-						<reference key="object" ref="761323775"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="906889126"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5405</string>
-						<reference key="object" ref="906889126"/>
-						<reference key="parent" ref="761323775"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5403</string>
-						<reference key="object" ref="1022082829"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="833542503"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">5406</string>
-						<reference key="object" ref="833542503"/>
-						<reference key="parent" ref="1022082829"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">9t3-JG-c1l</string>
-						<reference key="object" ref="709218819"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="436440005"/>
-							<reference ref="700963246"/>
-							<reference ref="206891834"/>
-							<reference ref="229099685"/>
-							<reference ref="258381978"/>
-							<reference ref="621104276"/>
-							<reference ref="165705421"/>
-							<reference ref="142713239"/>
-							<reference ref="666556728"/>
-						</array>
-						<reference key="parent" ref="159800861"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">hLW-S6-RZ9</string>
-						<reference key="object" ref="436440005"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="314304383"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">Mkf-Q4-7vt</string>
-						<reference key="object" ref="700963246"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="505754417"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">3Y2-Rj-0be</string>
-						<reference key="object" ref="206891834"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="624179436"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">zor-qs-az3</string>
-						<reference key="object" ref="229099685"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="371886454"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">7nJ-pZ-buy</string>
-						<reference key="object" ref="258381978"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="79502833"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">XLC-w6-o5W</string>
-						<reference key="object" ref="621104276"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="781228352"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">vPP-gd-c4a</string>
-						<reference key="object" ref="165705421"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="74900653"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">VqZ-mo-IXW</string>
-						<reference key="object" ref="142713239"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="946439447"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">7eD-3o-HAJ</string>
-						<reference key="object" ref="666556728"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="345867488"/>
-						</array>
-						<reference key="parent" ref="709218819"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">XZJ-kZ-hgG</string>
-						<reference key="object" ref="345867488"/>
-						<reference key="parent" ref="666556728"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">dlS-N8-67W</string>
-						<reference key="object" ref="946439447"/>
-						<reference key="parent" ref="142713239"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">OCU-fz-H9W</string>
-						<reference key="object" ref="74900653"/>
-						<reference key="parent" ref="165705421"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">QTm-ne-rcS</string>
-						<reference key="object" ref="781228352"/>
-						<reference key="parent" ref="621104276"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">30l-FF-qhV</string>
-						<reference key="object" ref="79502833"/>
-						<reference key="parent" ref="258381978"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">m4Z-qz-MVB</string>
-						<reference key="object" ref="371886454"/>
-						<reference key="parent" ref="229099685"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">ldB-Kc-oTh</string>
-						<reference key="object" ref="624179436"/>
-						<reference key="parent" ref="206891834"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">xGU-pV-iYc</string>
-						<reference key="object" ref="505754417"/>
-						<reference key="parent" ref="700963246"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">wO6-xE-Gjg</string>
-						<reference key="object" ref="314304383"/>
-						<reference key="parent" ref="436440005"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">FtV-HG-DIU</string>
-						<reference key="object" ref="1003668465"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="994249095"/>
-						</array>
-						<reference key="parent" ref="326102394"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">w3N-9r-DzN</string>
-						<reference key="object" ref="994249095"/>
-						<reference key="parent" ref="1003668465"/>
-					</object>
-					<object class="IBObjectRecord">
-						<string key="id">25V-E5-s4p</string>
-						<reference key="object" ref="660097916"/>
-						<reference key="parent" ref="642202204"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="25V-E5-s4p.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="30l-FF-qhV.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="3Y2-Rj-0be.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4829.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4839.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="4888.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="4888.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4910.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4911.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4912.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4913.CustomClassName">SPFavoritesOutlineView</string>
-				<string key="4913.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4915.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4918.CustomClassName">SPFavoriteTextFieldCell</string>
-				<string key="4918.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="4980.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">InitialTabViewItem</string>
-					<object class="IBInitialTabViewItemAttribute" key="NS.object.0">
-						<string key="name">InitialTabViewItem</string>
-						<reference key="object" ref="134031646"/>
-						<reference key="initialTabViewItem" ref="253369045"/>
-					</object>
-				</object>
-				<string key="4980.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4981.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4982.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4983.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4984.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4985.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="4986.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5154.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5155.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5156.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5157.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5158.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5162.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5166.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5171.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="644973446"/>
-						<string key="toolTip">Enter the hostname of the MySQL server you want to connect to.  Enter 127.0.0.1 to connect to a server on this computer</string>
-					</object>
-				</object>
-				<string key="5171.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5172.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5173.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5174.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5175.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="978463433"/>
-						<string key="toolTip">Enter the MySQL username to connect with</string>
-					</object>
-				</object>
-				<string key="5175.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5176.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5177.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5178.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5179.CustomClassName">NSSecureTextField</string>
-				<object class="NSMutableDictionary" key="5179.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="211629203"/>
-						<string key="toolTip">Enter the password to use when connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5179.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5180.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5181.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5182.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5183.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="950381827"/>
-						<string key="toolTip">Optionally enter a database to select after successfully connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5183.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5184.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5185.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5186.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5187.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1013612483"/>
-						<string key="toolTip">Enter the port to use when connecting to the MySQL server.  The default MySQL port is 3306</string>
-					</object>
-				</object>
-				<string key="5187.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5188.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5189.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5190.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5212.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="68541783"/>
-						<string key="toolTip">Enter the MySQL username to connect with</string>
-					</object>
-				</object>
-				<string key="5212.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5213.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5214.CustomClassName">NSSecureTextField</string>
-				<object class="NSMutableDictionary" key="5214.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="512253301"/>
-						<string key="toolTip">Enter the password to use when connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5214.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5215.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5216.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="58217156"/>
-						<string key="toolTip">Optionally enter a database to select after successfully connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5216.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5217.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5218.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="728228957"/>
-						<string key="toolTip">Enter the path to the socket file to use when connecting to MySQL.  Leave this field blank to use the default socket location</string>
-					</object>
-				</object>
-				<string key="5218.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5219.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5220.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5221.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5222.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5223.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5224.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5225.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5226.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5227.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5264.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1030226140"/>
-						<string key="toolTip">Enter the hostname of the MySQL server you want to connect to.  Enter 127.0.0.1 to connect to a server running on the machine you are tunnelling to</string>
-					</object>
-				</object>
-				<string key="5264.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5265.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5266.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="358903996"/>
-						<string key="toolTip">Enter the MySQL username to connect with</string>
-					</object>
-				</object>
-				<string key="5266.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5267.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5268.CustomClassName">NSSecureTextField</string>
-				<object class="NSMutableDictionary" key="5268.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="187191991"/>
-						<string key="toolTip">Enter the password to use when connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5268.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5269.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5270.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1000646962"/>
-						<string key="toolTip">Optionally enter a database to select after successfully connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5270.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5271.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5272.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1049720725"/>
-						<string key="toolTip">Enter the port to use when connecting to the MySQL server.  The default MySQL port is 3306</string>
-					</object>
-				</object>
-				<string key="5272.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5273.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5274.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5275.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5276.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5277.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5278.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5279.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5280.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5281.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5282.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5283.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5284.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="844385120"/>
-						<string key="toolTip">Enter the hostname of the SSH server to tunnel via when connecting to the MySQL server</string>
-					</object>
-				</object>
-				<string key="5284.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5285.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5286.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="790983747"/>
-						<string key="toolTip">Enter the SSH username to connect with</string>
-					</object>
-				</object>
-				<string key="5286.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5287.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5288.CustomClassName">NSSecureTextField</string>
-				<object class="NSMutableDictionary" key="5288.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="21480939"/>
-						<string key="toolTip">Enter the password to use when connecting to the SSH server. NB: your SSH configuration is used, and public/private key pairs and other authentication methods will be used if available</string>
-					</object>
-				</object>
-				<string key="5288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5289.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5290.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="692784990"/>
-						<string key="toolTip">Enter the port to use when connecting to the SSH server.  The default SSH port is 22</string>
-					</object>
-				</object>
-				<string key="5290.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5291.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5292.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5293.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5294.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5295.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5296.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5297.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5298.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5299.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5376.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="810791200"/>
-						<string key="toolTip">Enter a nickname to use if adding to favorites. Optional.</string>
-					</object>
-				</object>
-				<string key="5376.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5377.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5378.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5379.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5385.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="474825058"/>
-						<string key="toolTip">Enter a nickname to use if adding to favorites. Optional.</string>
-					</object>
-				</object>
-				<string key="5385.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5386.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5387.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<dictionary class="NSMutableDictionary" key="5388.IBAttributePlaceholdersKey"/>
-				<string key="5388.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5403.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1022082829"/>
-						<string key="toolTip">Enter a nickname to use if adding to favorites. Optional.</string>
-					</object>
-				</object>
-				<string key="5403.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5404.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5405.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5406.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5422.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5423.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5424.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5431.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5431.IBWindowTemplateEditedContentRect">{{476, 64}, {580, 320}}</string>
-				<boolean value="NO" key="5431.NSWindowTemplate.visibleAtLaunch"/>
-				<string key="5432.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5433.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5434.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5435.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5436.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5447.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5455.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5492.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="183948302"/>
-						<string key="toolTip">Choose a custom SSH key file to use with this connection.  Standard locations like ~/.ssh are checked automatically.</string>
-					</object>
-				</object>
-				<string key="5492.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5493.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5523.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5524.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5525.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5526.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5576.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5577.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5578.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5588.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5589.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5590.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5593.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5594.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5595.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5596.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5597.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5598.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5599.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5600.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="586011242"/>
-						<string key="toolTip">Click to choose the SSL private key file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5600.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5601.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5604.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="945929172"/>
-						<string key="toolTip">Click to choose the client SSL certificate file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5604.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5605.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5606.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5607.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5608.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5609.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5612.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="839299955"/>
-						<string key="toolTip">Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5612.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5613.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5614.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5615.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5616.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5617.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5668.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5669.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5670.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5680.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5681.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5682.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5683.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5684.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5685.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5688.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5689.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5690.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5691.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="680939705"/>
-						<string key="toolTip">Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5691.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5692.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5693.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5694.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="988136593"/>
-						<string key="toolTip">Click to choose the client SSL certificate file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5694.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="5695.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="237955939"/>
-						<string key="toolTip">Click to choose the SSL private key file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="5695.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5696.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5697.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5698.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5699.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5700.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5701.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5702.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5703.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5704.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5705.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5706.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5720.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5721.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5739.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5741.CustomClassName">SPSplitView</string>
-				<string key="5741.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5742.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5743.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5748.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5749.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5756.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5757.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5760.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5761.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5764.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5765.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5788.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5789.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5790.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5791.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5792.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5793.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5794.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5795.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5796.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5797.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5798.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5822.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5823.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5824.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5825.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5826.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5833.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5834.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5835.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5836.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5837.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5838.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5839.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5840.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5841.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5842.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5843.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<dictionary class="NSMutableDictionary" key="5851.IBAttributePlaceholdersKey"/>
-				<string key="5851.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5852.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<dictionary class="NSMutableDictionary" key="5853.IBAttributePlaceholdersKey"/>
-				<string key="5853.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5854.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5858.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5859.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<reference key="5862.IBNSViewMetadataGestureRecognizers" ref="0"/>
-				<string key="5862.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5863.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5864.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5865.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5866.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5869.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5870.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5883.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5884.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5885.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5886.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5887.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5892.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5894.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5896.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5898.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="7eD-3o-HAJ.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="666556728"/>
-						<string key="toolTip">Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="7eD-3o-HAJ.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="7nJ-pZ-buy.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9t3-JG-c1l.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="FtV-HG-DIU.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="Mkf-Q4-7vt.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="OCU-fz-H9W.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="QTm-ne-rcS.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="VqZ-mo-IXW.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="142713239"/>
-						<string key="toolTip">Click to choose the client SSL certificate file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="VqZ-mo-IXW.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="XLC-w6-o5W.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="XZJ-kZ-hgG.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="dlS-N8-67W.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="hLW-S6-RZ9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="ldB-Kc-oTh.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="m4Z-qz-MVB.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="vPP-gd-c4a.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="165705421"/>
-						<string key="toolTip">Click to choose the SSL private key file to use when establishing a secure connection.</string>
-					</object>
-				</object>
-				<string key="vPP-gd-c4a.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="w3N-9r-DzN.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="wO6-xE-Gjg.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="xGU-pV-iYc.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="zor-qs-az3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">ImageAndTextCell</string>
-					<string key="superclassName">NSTextFieldCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/ImageAndTextCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextView</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="doDecomposedStringWithCanonicalMapping:">id</string>
-						<string key="doDecomposedStringWithCompatibilityMapping:">id</string>
-						<string key="doPrecomposedStringWithCanonicalMapping:">id</string>
-						<string key="doPrecomposedStringWithCompatibilityMapping:">id</string>
-						<string key="doRemoveDiacritics:">id</string>
-						<string key="doSelectionLowerCase:">id</string>
-						<string key="doSelectionTitleCase:">id</string>
-						<string key="doSelectionUpperCase:">id</string>
-						<string key="doTranspose:">id</string>
-						<string key="executeBundleItemForInputField:">id</string>
-						<string key="insertNULLvalue:">id</string>
-						<string key="moveSelectionLineDown:">id</string>
-						<string key="moveSelectionLineUp:">id</string>
-						<string key="selectCurrentLine:">id</string>
-						<string key="selectCurrentWord:">id</string>
-						<string key="selectEnclosingBrackets:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="doDecomposedStringWithCanonicalMapping:">
-							<string key="name">doDecomposedStringWithCanonicalMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doDecomposedStringWithCompatibilityMapping:">
-							<string key="name">doDecomposedStringWithCompatibilityMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doPrecomposedStringWithCanonicalMapping:">
-							<string key="name">doPrecomposedStringWithCanonicalMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doPrecomposedStringWithCompatibilityMapping:">
-							<string key="name">doPrecomposedStringWithCompatibilityMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doRemoveDiacritics:">
-							<string key="name">doRemoveDiacritics:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionLowerCase:">
-							<string key="name">doSelectionLowerCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionTitleCase:">
-							<string key="name">doSelectionTitleCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionUpperCase:">
-							<string key="name">doSelectionUpperCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doTranspose:">
-							<string key="name">doTranspose:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="executeBundleItemForInputField:">
-							<string key="name">executeBundleItemForInputField:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="insertNULLvalue:">
-							<string key="name">insertNULLvalue:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="moveSelectionLineDown:">
-							<string key="name">moveSelectionLineDown:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="moveSelectionLineUp:">
-							<string key="name">moveSelectionLineUp:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectCurrentLine:">
-							<string key="name">selectCurrentLine:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectCurrentWord:">
-							<string key="name">selectCurrentWord:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectEnclosingBrackets:">
-							<string key="name">selectEnclosingBrackets:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPTextViewAdditions.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextView</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="doDecomposedStringWithCanonicalMapping:">id</string>
-						<string key="doDecomposedStringWithCompatibilityMapping:">id</string>
-						<string key="doPrecomposedStringWithCanonicalMapping:">id</string>
-						<string key="doPrecomposedStringWithCompatibilityMapping:">id</string>
-						<string key="doRemoveDiacritics:">id</string>
-						<string key="doSelectionLowerCase:">id</string>
-						<string key="doSelectionTitleCase:">id</string>
-						<string key="doSelectionUpperCase:">id</string>
-						<string key="doTranspose:">id</string>
-						<string key="executeBundleItemForInputField:">id</string>
-						<string key="insertNULLvalue:">id</string>
-						<string key="moveSelectionLineDown:">id</string>
-						<string key="moveSelectionLineUp:">id</string>
-						<string key="selectCurrentLine:">id</string>
-						<string key="selectCurrentWord:">id</string>
-						<string key="selectEnclosingBrackets:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="doDecomposedStringWithCanonicalMapping:">
-							<string key="name">doDecomposedStringWithCanonicalMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doDecomposedStringWithCompatibilityMapping:">
-							<string key="name">doDecomposedStringWithCompatibilityMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doPrecomposedStringWithCanonicalMapping:">
-							<string key="name">doPrecomposedStringWithCanonicalMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doPrecomposedStringWithCompatibilityMapping:">
-							<string key="name">doPrecomposedStringWithCompatibilityMapping:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doRemoveDiacritics:">
-							<string key="name">doRemoveDiacritics:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionLowerCase:">
-							<string key="name">doSelectionLowerCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionTitleCase:">
-							<string key="name">doSelectionTitleCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doSelectionUpperCase:">
-							<string key="name">doSelectionUpperCase:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doTranspose:">
-							<string key="name">doTranspose:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="executeBundleItemForInputField:">
-							<string key="name">executeBundleItemForInputField:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="insertNULLvalue:">
-							<string key="name">insertNULLvalue:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="moveSelectionLineDown:">
-							<string key="name">moveSelectionLineDown:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="moveSelectionLineUp:">
-							<string key="name">moveSelectionLineUp:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectCurrentLine:">
-							<string key="name">selectCurrentLine:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectCurrentWord:">
-							<string key="name">selectCurrentWord:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectEnclosingBrackets:">
-							<string key="name">selectEnclosingBrackets:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPTextViewAdditions.m</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPColorSelectorView</string>
-					<string key="superclassName">NSView</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">delegate</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">delegate</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">delegate</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPColorSelectorView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPConnectionController</string>
-					<string key="superclassName">NSViewController</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="addFavorite:">id</string>
-						<string key="addFavoriteUsingCurrentDetails:">id</string>
-						<string key="addGroup:">id</string>
-						<string key="cancelConnection:">id</string>
-						<string key="chooseKeyLocation:">id</string>
-						<string key="duplicateFavorite:">id</string>
-						<string key="exportFavorites:">id</string>
-						<string key="importFavorites:">id</string>
-						<string key="initiateConnection:">id</string>
-						<string key="makeSelectedFavoriteDefault:">id</string>
-						<string key="nodeDoubleClicked:">id</string>
-						<string key="removeNode:">id</string>
-						<string key="renameNode:">id</string>
-						<string key="reverseSortFavorites:">NSMenuItem</string>
-						<string key="saveFavorite:">id</string>
-						<string key="showHelp:">id</string>
-						<string key="sortFavorites:">id</string>
-						<string key="updateKeyLocationFileVisibility:">id</string>
-						<string key="updateSSLInterface:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="addFavorite:">
-							<string key="name">addFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addFavoriteUsingCurrentDetails:">
-							<string key="name">addFavoriteUsingCurrentDetails:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addGroup:">
-							<string key="name">addGroup:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="cancelConnection:">
-							<string key="name">cancelConnection:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="chooseKeyLocation:">
-							<string key="name">chooseKeyLocation:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="duplicateFavorite:">
-							<string key="name">duplicateFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="exportFavorites:">
-							<string key="name">exportFavorites:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="importFavorites:">
-							<string key="name">importFavorites:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="initiateConnection:">
-							<string key="name">initiateConnection:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="makeSelectedFavoriteDefault:">
-							<string key="name">makeSelectedFavoriteDefault:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="nodeDoubleClicked:">
-							<string key="name">nodeDoubleClicked:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="removeNode:">
-							<string key="name">removeNode:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="renameNode:">
-							<string key="name">renameNode:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="reverseSortFavorites:">
-							<string key="name">reverseSortFavorites:</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBActionInfo" key="saveFavorite:">
-							<string key="name">saveFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showHelp:">
-							<string key="name">showHelp:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="sortFavorites:">
-							<string key="name">sortFavorites:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="updateKeyLocationFileVisibility:">
-							<string key="name">updateKeyLocationFileVisibility:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="updateSSLInterface:">
-							<string key="name">updateSSLInterface:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="connectButton">NSButton</string>
-						<string key="connectionDetailsScrollView">NSScrollView</string>
-						<string key="connectionInstructionsTextField">NSTextField</string>
-						<string key="connectionResizeContainer">NSView</string>
-						<string key="connectionSplitView">SPSplitView</string>
-						<string key="connectionView">NSView</string>
-						<string key="editButtonsView">NSView</string>
-						<string key="errorDetailText">NSTextView</string>
-						<string key="errorDetailWindow">NSWindow</string>
-						<string key="exportPanelAccessoryView">NSView</string>
-						<string key="favoritesOutlineView">SPFavoritesOutlineView</string>
-						<string key="favoritesSortByMenuItem">NSMenuItem</string>
-						<string key="helpButton">NSButton</string>
-						<string key="progressIndicator">NSProgressIndicator</string>
-						<string key="progressIndicatorText">NSTextField</string>
-						<string key="saveFavoriteButton">NSButton</string>
-						<string key="socketColorField">SPColorSelectorView</string>
-						<string key="socketConnectionFormContainer">NSView</string>
-						<string key="socketConnectionSSLDetailsContainer">NSView</string>
-						<string key="socketNameField">NSTextField</string>
-						<string key="socketPasswordField">NSSecureTextField</string>
-						<string key="socketSSLCACertButton">NSButton</string>
-						<string key="socketSSLCertificateButton">NSButton</string>
-						<string key="socketSSLKeyFileButton">NSButton</string>
-						<string key="socketUserField">NSTextField</string>
-						<string key="sshColorField">SPColorSelectorView</string>
-						<string key="sshConnectionFormContainer">NSView</string>
-						<string key="sshConnectionSSLDetailsContainer">NSView</string>
-						<string key="sshKeyLocationHelp">NSView</string>
-						<string key="sshNameField">NSTextField</string>
-						<string key="sshPasswordField">NSSecureTextField</string>
-						<string key="sshSQLHostField">NSTextField</string>
-						<string key="sshSSHKeyButton">NSButton</string>
-						<string key="sshSSHPasswordField">NSSecureTextField</string>
-						<string key="sshUserField">NSTextField</string>
-						<string key="sslCACertLocationHelp">NSView</string>
-						<string key="sslCertificateLocationHelp">NSView</string>
-						<string key="sslKeyFileLocationHelp">NSView</string>
-						<string key="sslOverSSHCACertButton">NSButton</string>
-						<string key="sslOverSSHCertificateButton">NSButton</string>
-						<string key="sslOverSSHKeyFileButton">NSButton</string>
-						<string key="standardColorField">SPColorSelectorView</string>
-						<string key="standardConnectionFormContainer">NSView</string>
-						<string key="standardConnectionSSLDetailsContainer">NSView</string>
-						<string key="standardNameField">NSTextField</string>
-						<string key="standardPasswordField">NSSecureTextField</string>
-						<string key="standardSQLHostField">NSTextField</string>
-						<string key="standardSSLCACertButton">NSButton</string>
-						<string key="standardSSLCertificateButton">NSButton</string>
-						<string key="standardSSLKeyFileButton">NSButton</string>
-						<string key="standardUserField">NSTextField</string>
-						<string key="testConnectButton">NSButton</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="connectButton">
-							<string key="name">connectButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="connectionDetailsScrollView">
-							<string key="name">connectionDetailsScrollView</string>
-							<string key="candidateClassName">NSScrollView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="connectionInstructionsTextField">
-							<string key="name">connectionInstructionsTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="connectionResizeContainer">
-							<string key="name">connectionResizeContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="connectionSplitView">
-							<string key="name">connectionSplitView</string>
-							<string key="candidateClassName">SPSplitView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="connectionView">
-							<string key="name">connectionView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="editButtonsView">
-							<string key="name">editButtonsView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="errorDetailText">
-							<string key="name">errorDetailText</string>
-							<string key="candidateClassName">NSTextView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="errorDetailWindow">
-							<string key="name">errorDetailWindow</string>
-							<string key="candidateClassName">NSWindow</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="exportPanelAccessoryView">
-							<string key="name">exportPanelAccessoryView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="favoritesOutlineView">
-							<string key="name">favoritesOutlineView</string>
-							<string key="candidateClassName">SPFavoritesOutlineView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="favoritesSortByMenuItem">
-							<string key="name">favoritesSortByMenuItem</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="helpButton">
-							<string key="name">helpButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="progressIndicator">
-							<string key="name">progressIndicator</string>
-							<string key="candidateClassName">NSProgressIndicator</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="progressIndicatorText">
-							<string key="name">progressIndicatorText</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="saveFavoriteButton">
-							<string key="name">saveFavoriteButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketColorField">
-							<string key="name">socketColorField</string>
-							<string key="candidateClassName">SPColorSelectorView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketConnectionFormContainer">
-							<string key="name">socketConnectionFormContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketConnectionSSLDetailsContainer">
-							<string key="name">socketConnectionSSLDetailsContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketNameField">
-							<string key="name">socketNameField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketPasswordField">
-							<string key="name">socketPasswordField</string>
-							<string key="candidateClassName">NSSecureTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketSSLCACertButton">
-							<string key="name">socketSSLCACertButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketSSLCertificateButton">
-							<string key="name">socketSSLCertificateButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketSSLKeyFileButton">
-							<string key="name">socketSSLKeyFileButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="socketUserField">
-							<string key="name">socketUserField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshColorField">
-							<string key="name">sshColorField</string>
-							<string key="candidateClassName">SPColorSelectorView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshConnectionFormContainer">
-							<string key="name">sshConnectionFormContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshConnectionSSLDetailsContainer">
-							<string key="name">sshConnectionSSLDetailsContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshKeyLocationHelp">
-							<string key="name">sshKeyLocationHelp</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshNameField">
-							<string key="name">sshNameField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshPasswordField">
-							<string key="name">sshPasswordField</string>
-							<string key="candidateClassName">NSSecureTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshSQLHostField">
-							<string key="name">sshSQLHostField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshSSHKeyButton">
-							<string key="name">sshSSHKeyButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshSSHPasswordField">
-							<string key="name">sshSSHPasswordField</string>
-							<string key="candidateClassName">NSSecureTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sshUserField">
-							<string key="name">sshUserField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslCACertLocationHelp">
-							<string key="name">sslCACertLocationHelp</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslCertificateLocationHelp">
-							<string key="name">sslCertificateLocationHelp</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslKeyFileLocationHelp">
-							<string key="name">sslKeyFileLocationHelp</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslOverSSHCACertButton">
-							<string key="name">sslOverSSHCACertButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslOverSSHCertificateButton">
-							<string key="name">sslOverSSHCertificateButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sslOverSSHKeyFileButton">
-							<string key="name">sslOverSSHKeyFileButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardColorField">
-							<string key="name">standardColorField</string>
-							<string key="candidateClassName">SPColorSelectorView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardConnectionFormContainer">
-							<string key="name">standardConnectionFormContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardConnectionSSLDetailsContainer">
-							<string key="name">standardConnectionSSLDetailsContainer</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardNameField">
-							<string key="name">standardNameField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardPasswordField">
-							<string key="name">standardPasswordField</string>
-							<string key="candidateClassName">NSSecureTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardSQLHostField">
-							<string key="name">standardSQLHostField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardSSLCACertButton">
-							<string key="name">standardSSLCACertButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardSSLCertificateButton">
-							<string key="name">standardSSLCertificateButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardSSLKeyFileButton">
-							<string key="name">standardSSLKeyFileButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="standardUserField">
-							<string key="name">standardUserField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="testConnectButton">
-							<string key="name">testConnectButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPConnectionController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPConnectionController</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="addFavorite:">id</string>
-						<string key="addFavoriteUsingCurrentDetails:">id</string>
-						<string key="addGroup:">id</string>
-						<string key="cancelConnection:">id</string>
-						<string key="chooseKeyLocation:">NSButton</string>
-						<string key="duplicateFavorite:">id</string>
-						<string key="exportFavorites:">id</string>
-						<string key="importFavorites:">id</string>
-						<string key="initiateConnection:">id</string>
-						<string key="makeSelectedFavoriteDefault:">id</string>
-						<string key="nodeDoubleClicked:">id</string>
-						<string key="removeNode:">id</string>
-						<string key="renameNode:">id</string>
-						<string key="saveFavorite:">id</string>
-						<string key="showHelp:">id</string>
-						<string key="updateKeyLocationFileVisibility:">id</string>
-						<string key="updateSSLInterface:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="addFavorite:">
-							<string key="name">addFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addFavoriteUsingCurrentDetails:">
-							<string key="name">addFavoriteUsingCurrentDetails:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addGroup:">
-							<string key="name">addGroup:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="cancelConnection:">
-							<string key="name">cancelConnection:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="chooseKeyLocation:">
-							<string key="name">chooseKeyLocation:</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBActionInfo" key="duplicateFavorite:">
-							<string key="name">duplicateFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="exportFavorites:">
-							<string key="name">exportFavorites:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="importFavorites:">
-							<string key="name">importFavorites:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="initiateConnection:">
-							<string key="name">initiateConnection:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="makeSelectedFavoriteDefault:">
-							<string key="name">makeSelectedFavoriteDefault:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="nodeDoubleClicked:">
-							<string key="name">nodeDoubleClicked:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="removeNode:">
-							<string key="name">removeNode:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="renameNode:">
-							<string key="name">renameNode:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="saveFavorite:">
-							<string key="name">saveFavorite:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showHelp:">
-							<string key="name">showHelp:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="updateKeyLocationFileVisibility:">
-							<string key="name">updateKeyLocationFileVisibility:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="updateSSLInterface:">
-							<string key="name">updateSSLInterface:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPConnectionController.m</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPFavoriteTextFieldCell</string>
-					<string key="superclassName">ImageAndTextCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPFavoriteTextFieldCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPFavoritesOutlineView</string>
-					<string key="superclassName">NSOutlineView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPFavoritesOutlineView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPFlippedView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPFlippedView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPSplitView</string>
-					<string key="superclassName">NSSplitView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">toggleCollapse:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="additionalDragHandleView">NSView</string>
-						<string key="collapseToggleButton">NSButton</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="additionalDragHandleView">
-							<string key="name">additionalDragHandleView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="collapseToggleButton">
-							<string key="name">collapseToggleButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPSplitView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SPSplitView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">toggleCollapse:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Source/SPSplitView.m</string>
-					</object>
-				</object>
-			</array>
-			<array class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<object class="IBPartialClassDescription">
-					<string key="className">NSActionCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButton</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButtonCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSCell</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSControl</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFormatter</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSImageCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSImageCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSImageView</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSImageView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenu</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenuItem</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenuItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenuItemCell</string>
-					<string key="superclassName">NSButtonCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenuItemCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSOutlineView</string>
-					<string key="superclassName">NSTableView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSOutlineView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPanel</string>
-					<string key="superclassName">NSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPanel.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPopUpButton</string>
-					<string key="superclassName">NSButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPopUpButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSPopUpButtonCell</string>
-					<string key="superclassName">NSMenuItemCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSPopUpButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSProgressIndicator</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSProgressIndicator.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSResponder</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSScrollView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSScrollView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSScroller</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSScroller.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSecureTextField</string>
-					<string key="superclassName">NSTextField</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSecureTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSSplitView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSSplitView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTabView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTabView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTabViewItem</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTabViewItem.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTableColumn</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTableColumn.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTableView</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTableView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSText</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSText.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextField</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextFieldCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextView</string>
-					<string key="superclassName">NSText</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSUserDefaultsController</string>
-					<string key="superclassName">NSController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSUserDefaultsController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSViewController</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">view</string>
-						<string key="NS.object.0">NSView</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">view</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">view</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSWindow</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSWindow.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">YES</bool>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<integer value="4600" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
-			<string key="NSSwitch">{15, 15}</string>
-			<string key="button_action">{32, 23}</string>
-			<string key="button_add">{32, 23}</string>
-			<string key="button_add_folder">{32, 23}</string>
-			<string key="button_bar_handle">{15, 23}</string>
-			<string key="button_bar_spacer">{10, 23}</string>
-			<string key="key-icon">{16, 9}</string>
-			<string key="key-icon-alternate">{16, 9}</string>
-		</dictionary>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="SPConnectionController">
+            <connections>
+                <outlet property="connectButton" destination="5157" id="5444"/>
+                <outlet property="connectionDetailsScrollView" destination="5588" id="5592"/>
+                <outlet property="connectionInstructionsTextField" destination="5154" id="5800"/>
+                <outlet property="connectionResizeContainer" destination="4888" id="5164"/>
+                <outlet property="connectionSplitView" destination="5741" id="5745"/>
+                <outlet property="connectionView" destination="5739" id="5740"/>
+                <outlet property="editButtonsView" destination="5862" id="5882"/>
+                <outlet property="errorDetailText" destination="5434" id="5437"/>
+                <outlet property="errorDetailWindow" destination="5431" id="5438"/>
+                <outlet property="exportPanelAccessoryView" destination="5796" id="5799"/>
+                <outlet property="favoritesOutlineView" destination="4913" id="5768"/>
+                <outlet property="favoritesSortByMenuItem" destination="5837" id="5850"/>
+                <outlet property="helpButton" destination="4829" id="5458"/>
+                <outlet property="progressIndicator" destination="5422" id="5426"/>
+                <outlet property="progressIndicatorText" destination="5423" id="5425"/>
+                <outlet property="saveFavoriteButton" destination="5869" id="5874"/>
+                <outlet property="socketColorField" destination="5896" id="5897"/>
+                <outlet property="socketConnectionFormContainer" destination="5162" id="5163"/>
+                <outlet property="socketConnectionSSLDetailsContainer" destination="5688" id="5724"/>
+                <outlet property="socketNameField" destination="5385" id="5806"/>
+                <outlet property="socketPasswordField" destination="5214" id="5428"/>
+                <outlet property="socketSSLCACertButton" destination="5691" id="5725"/>
+                <outlet property="socketSSLCertificateButton" destination="5694" id="5726"/>
+                <outlet property="socketSSLKeyFileButton" destination="5695" id="nQE-St-ai8"/>
+                <outlet property="socketUserField" destination="5212" id="5807"/>
+                <outlet property="sshColorField" destination="5898" id="5899"/>
+                <outlet property="sshConnectionFormContainer" destination="5166" id="5167"/>
+                <outlet property="sshConnectionSSLDetailsContainer" destination="9t3-JG-c1l" id="K8K-hl-nke"/>
+                <outlet property="sshKeyLocationHelp" destination="5576" id="5579"/>
+                <outlet property="sshNameField" destination="5403" id="5893"/>
+                <outlet property="sshPasswordField" destination="5268" id="5429"/>
+                <outlet property="sshSQLHostField" destination="5264" id="5445"/>
+                <outlet property="sshSSHKeyButton" destination="5492" id="5494"/>
+                <outlet property="sshSSHPasswordField" destination="5288" id="5430"/>
+                <outlet property="sshUserField" destination="5212" id="5808"/>
+                <outlet property="sslCACertLocationHelp" destination="5680" id="5686"/>
+                <outlet property="sslCertificateLocationHelp" destination="5683" id="5687"/>
+                <outlet property="sslKeyFileLocationHelp" destination="5668" id="5671"/>
+                <outlet property="sslOverSSHCACertButton" destination="7eD-3o-HAJ" id="1Wh-DE-z2l"/>
+                <outlet property="sslOverSSHCertificateButton" destination="VqZ-mo-IXW" id="Ync-fQ-3aq"/>
+                <outlet property="sslOverSSHKeyFileButton" destination="vPP-gd-c4a" id="VTR-AE-QPt"/>
+                <outlet property="standardColorField" destination="5894" id="5895"/>
+                <outlet property="standardConnectionFormContainer" destination="5156" id="5161"/>
+                <outlet property="standardConnectionSSLDetailsContainer" destination="5595" id="5620"/>
+                <outlet property="standardNameField" destination="5376" id="5810"/>
+                <outlet property="standardPasswordField" destination="5179" id="5427"/>
+                <outlet property="standardSQLHostField" destination="5171" id="5446"/>
+                <outlet property="standardSSLCACertButton" destination="5612" id="5667"/>
+                <outlet property="standardSSLCertificateButton" destination="5604" id="5666"/>
+                <outlet property="standardSSLKeyFileButton" destination="5600" id="5665"/>
+                <outlet property="standardUserField" destination="5175" id="5811"/>
+                <outlet property="testConnectButton" destination="5863" id="5875"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="5739" userLabel="ConnectionView" customClass="SPFlippedView">
+            <rect key="frame" x="0.0" y="0.0" width="882" height="513"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <splitView autosaveName="DBViewSplitter" dividerStyle="thin" vertical="YES" id="5741" customClass="SPSplitView">
+                    <rect key="frame" x="0.0" y="0.0" width="882" height="513"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <subviews>
+                        <view id="5742">
+                            <rect key="frame" x="0.0" y="0.0" width="200" height="513"/>
+                            <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
+                            <subviews>
+                                <imageView id="5822">
+                                    <rect key="frame" x="0.0" y="1" width="200" height="22"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="button_bar_spacer" id="5823"/>
+                                </imageView>
+                                <button id="5853">
+                                    <rect key="frame" x="61" y="-1" width="32" height="25"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="button_add" imagePosition="overlaps" alignment="center" inset="2" id="5854">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="addFavorite:" target="-2" id="5857"/>
+                                    </connections>
+                                </button>
+                                <button id="5851">
+                                    <rect key="frame" x="30" y="-1" width="32" height="25"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="button_add_folder" imagePosition="overlaps" alignment="center" inset="2" id="5852">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="addGroup:" target="-2" id="5856"/>
+                                    </connections>
+                                </button>
+                                <popUpButton id="5824">
+                                    <rect key="frame" x="-2" y="0.0" width="36" height="23"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="right" alignment="center" lineBreakMode="truncatingTail" state="on" inset="2" pullsDown="YES" arrowPosition="noArrow" selectedItem="5833" id="5825">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu"/>
+                                        <menu key="menu" title="OtherViews" id="5826">
+                                            <items>
+                                                <menuItem state="on" image="button_action" hidden="YES" id="5833"/>
+                                                <menuItem title="Rename" id="5883">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="renameNode:" target="-2" id="5890"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem title="Remove" id="5884">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="removeNode:" target="-2" id="5891"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem isSeparatorItem="YES" id="5885"/>
+                                                <menuItem title="Duplicate" id="5886">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="duplicateFavorite:" target="-2" id="5888"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem isSeparatorItem="YES" id="5892"/>
+                                                <menuItem title="Import..." id="5834">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="importFavorites:" target="-2" id="5849"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem title="Export..." id="5835">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="exportFavorites:" target="-2" id="5844"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem isSeparatorItem="YES" id="5836"/>
+                                                <menuItem title="Make Default" id="5887">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="makeSelectedFavoriteDefault:" target="-2" id="5889"/>
+                                                    </connections>
+                                                </menuItem>
+                                                <menuItem title="Sort By" id="5837">
+                                                    <menu key="submenu" title="Sort By" id="5838">
+                                                        <items>
+                                                            <menuItem title="Name" id="5843">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="sortFavorites:" target="-2" id="5846"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Host" id="5842">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="sortFavorites:" target="-2" id="5847"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Type" id="5841">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="sortFavorites:" target="-2" id="5845"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Color" id="25V-E5-s4p">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="sortFavorites:" target="-2" id="Q9D-q1-jts"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem isSeparatorItem="YES" id="5840"/>
+                                                            <menuItem title="Reverse Sort Order" id="5839">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="reverseSortFavorites:" target="-2" id="5848"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                        </items>
+                                                    </menu>
+                                                </menuItem>
+                                            </items>
+                                        </menu>
+                                    </popUpButtonCell>
+                                </popUpButton>
+                                <imageView id="5858">
+                                    <rect key="frame" x="185" y="1" width="15" height="22"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="button_bar_handle" id="5859"/>
+                                </imageView>
+                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="4910">
+                                    <rect key="frame" x="0.0" y="23" width="200" height="489"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <clipView key="contentView" drawsBackground="NO" id="tVa-Tk-sNR">
+                                        <rect key="frame" x="0.0" y="0.0" width="200" height="489"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" id="4913" customClass="SPFavoritesOutlineView">
+                                                <rect key="frame" x="0.0" y="0.0" width="200" height="489"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <size key="intercellSpacing" width="3" height="2"/>
+                                                <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                <tableColumns>
+                                                    <tableColumn width="197" minWidth="40" maxWidth="1000" id="4915">
+                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Favorites">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                        </tableHeaderCell>
+                                                        <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="4918" customClass="SPFavoriteTextFieldCell">
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                        </textFieldCell>
+                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
+                                                    </tableColumn>
+                                                </tableColumns>
+                                                <connections>
+                                                    <outlet property="dataSource" destination="-2" id="5341"/>
+                                                    <outlet property="delegate" destination="-2" id="4930"/>
+                                                    <outlet property="menu" destination="5788" id="5812"/>
+                                                    <outlet property="nextKeyView" destination="4980" id="5466"/>
+                                                </connections>
+                                            </tableView>
+                                        </subviews>
+                                        <nil key="backgroundColor"/>
+                                    </clipView>
+                                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="4912">
+                                        <rect key="frame" x="1" y="525" width="228" height="15"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                    </scroller>
+                                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="4911">
+                                        <rect key="frame" x="229" y="1" width="15" height="524"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                    </scroller>
+                                </scrollView>
+                            </subviews>
+                        </view>
+                        <view id="5743">
+                            <rect key="frame" x="201" y="0.0" width="681" height="513"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="5588">
+                                    <rect key="frame" x="0.0" y="0.0" width="681" height="481"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <clipView key="contentView" id="k5Z-CG-bvr">
+                                        <rect key="frame" x="0.0" y="0.0" width="681" height="481"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <customView id="5447" customClass="SPFlippedView">
+                                                <rect key="frame" x="0.0" y="0.0" width="681" height="480"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                                <subviews>
+                                                    <customView id="4888" customClass="NSCustomView">
+                                                        <rect key="frame" x="116" y="5" width="446" height="472"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <subviews>
+                                                            <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="4829">
+                                                                <rect key="frame" x="3" y="37" width="25" height="25"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" state="on" borderStyle="border" inset="2" id="4839">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="showHelp:" target="-2" id="5351"/>
+                                                                </connections>
+                                                            </button>
+                                                            <textField hidden="YES" verticalHuggingPriority="750" id="5423">
+                                                                <rect key="frame" x="29" y="43" width="264" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Connecting..." id="5424">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" minValue="16" maxValue="100" doubleValue="16" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="5422">
+                                                                <rect key="frame" x="7" y="43" width="16" height="16"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                            </progressIndicator>
+                                                            <button verticalHuggingPriority="750" id="5157">
+                                                                <rect key="frame" x="295" y="33" width="147" height="32"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                                                <buttonCell key="cell" type="push" title="Connect" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5158">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="initiateConnection:" target="-2" id="5439"/>
+                                                                </connections>
+                                                            </button>
+                                                            <customView hidden="YES" id="5862" userLabel="Edit Connection Buttons Box">
+                                                                <rect key="frame" x="0.0" y="0.0" width="446" height="37"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                                                <subviews>
+                                                                    <button verticalHuggingPriority="750" id="5863">
+                                                                        <rect key="frame" x="297" y="3" width="146" height="28"/>
+                                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                                                        <buttonCell key="cell" type="push" title="Test connection" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5864">
+                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
+                                                                        </buttonCell>
+                                                                        <connections>
+                                                                            <action selector="initiateConnection:" target="-2" id="5881"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <button verticalHuggingPriority="750" id="5865">
+                                                                        <rect key="frame" x="3" y="3" width="157" height="28"/>
+                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                        <buttonCell key="cell" type="push" title="Add to Favorites" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5866">
+                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
+                                                                            <string key="keyEquivalent">a</string>
+                                                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                                        </buttonCell>
+                                                                        <connections>
+                                                                            <action selector="addFavoriteUsingCurrentDetails:" target="-2" id="5871"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <button verticalHuggingPriority="750" id="5869">
+                                                                        <rect key="frame" x="159" y="3" width="139" height="28"/>
+                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                        <buttonCell key="cell" type="push" title="Save changes" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5870">
+                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" metaFont="smallSystem"/>
+                                                                            <string key="keyEquivalent">s</string>
+                                                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                                                        </buttonCell>
+                                                                        <connections>
+                                                                            <action selector="saveFavorite:" target="-2" id="5880"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                </subviews>
+                                                            </customView>
+                                                            <tabView initialItem="4981" id="4980">
+                                                                <rect key="frame" x="3" y="61" width="440" height="417"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                <font key="font" metaFont="system"/>
+                                                                <tabViewItems>
+                                                                    <tabViewItem label="Standard (TCP/IP)" identifier="1" id="4981">
+                                                                        <view key="view" id="4984">
+                                                                            <rect key="frame" x="10" y="33" width="420" height="371"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                            <subviews>
+                                                                                <customView id="5156">
+                                                                                    <rect key="frame" x="22" y="101" width="377" height="287"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <textField verticalHuggingPriority="750" id="5188">
+                                                                                            <rect key="frame" x="7" y="44" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Port:" id="5189">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the port to use when connecting to the MySQL server.  The default MySQL port is 3306" verticalHuggingPriority="750" id="5187">
+                                                                                            <rect key="frame" x="110" y="42" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="3306" drawsBackground="YES" usesSingleLineMode="YES" id="5190">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="port" id="5418">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">3306</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5362"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5184">
+                                                                                            <rect key="frame" x="7" y="78" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Database:" id="5185">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Optionally enter a database to select after successfully connecting to the MySQL server" verticalHuggingPriority="750" id="5183">
+                                                                                            <rect key="frame" x="110" y="76" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5186">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="database" id="5417">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5361"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5180">
+                                                                                            <rect key="frame" x="7" y="112" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="5181">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the password to use when connecting to the MySQL server" verticalHuggingPriority="750" id="5179" customClass="NSSecureTextField">
+                                                                                            <rect key="frame" x="110" y="110" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5182">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="password" id="5203">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5360"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5176">
+                                                                                            <rect key="frame" x="7" y="146" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="5177">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the MySQL username to connect with" verticalHuggingPriority="750" id="5175">
+                                                                                            <rect key="frame" x="110" y="144" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5178">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="user" id="5199">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5359"/>
+                                                                                                <outlet property="nextKeyView" destination="5179" id="5464"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5377">
+                                                                                            <rect key="frame" x="7" y="240" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Name:" id="5378">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter a nickname to use if adding to favorites. Optional." verticalHuggingPriority="750" id="5376">
+                                                                                            <rect key="frame" x="110" y="238" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5379">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="name" id="5416">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5402"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5173">
+                                                                                            <rect key="frame" x="7" y="180" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Host:" id="5174">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the hostname of the MySQL server you want to connect to.  Enter 127.0.0.1 to connect to a server on this computer" verticalHuggingPriority="750" id="5171">
+                                                                                            <rect key="frame" x="110" y="178" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5172">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="host" id="5195">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <bool key="NSValidatesImmediately" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5358"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <button id="5593">
+                                                                                            <rect key="frame" x="108" y="14" width="251" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="check" title="Connect using SSL" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5594">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="updateSSLInterface:" target="-2" id="5651"/>
+                                                                                                <binding destination="-2" name="value" keyPath="useSSL" id="5627">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <customView id="5894" customClass="SPColorSelectorView">
+                                                                                            <rect key="frame" x="110" y="208" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <connections>
+                                                                                                <outlet property="delegate" destination="-2" id="5900"/>
+                                                                                            </connections>
+                                                                                        </customView>
+                                                                                    </subviews>
+                                                                                </customView>
+                                                                                <customView id="5595">
+                                                                                    <rect key="frame" x="22" y="-29" width="377" height="149"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <button toolTip="Click to choose the SSL private key file to use when establishing a secure connection." verticalHuggingPriority="750" id="5600">
+                                                                                            <rect key="frame" x="328" y="80" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5601">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5662"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocationEnabled" id="5673">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5596">
+                                                                                            <rect key="frame" x="109" y="81" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5597">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.50403225419999997" alpha="1" colorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslKeyFileLocation" id="5641"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocation" id="5732">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5598">
+                                                                                            <rect key="frame" x="-3" y="83" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Key File:" id="5599">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the client SSL certificate file to use when establishing a secure connection." verticalHuggingPriority="750" id="5604">
+                                                                                            <rect key="frame" x="328" y="46" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5609">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5663"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocationEnabled" id="5677">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5605">
+                                                                                            <rect key="frame" x="109" y="47" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5608">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCertificateFileLocation" id="5639"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocation" id="5731">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5606">
+                                                                                            <rect key="frame" x="-3" y="49" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Certificate:" id="5607">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection." verticalHuggingPriority="750" id="5612">
+                                                                                            <rect key="frame" x="328" y="12" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5617">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5664"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocationEnabled" id="5679">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5613">
+                                                                                            <rect key="frame" x="109" y="13" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5616">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCACertFileLocation" id="5637"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocation" id="5730">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5614">
+                                                                                            <rect key="frame" x="-3" y="15" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="CA Cert:" id="5615">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button id="EpB-TI-xrh">
+                                                                                            <rect key="frame" x="107" y="118" width="252" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <string key="toolTip">This option will send your password as plain text, and should only be used with SSL connections. If you're unsure, contact your systems administrator.</string>
+                                                                                            <buttonCell key="cell" type="check" title="Enable ClearText plugin" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="bfR-u3-FCP">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="enterEditMode:" target="-2" id="UbD-O9-we1"/>
+                                                                                                <binding destination="-2" name="value" keyPath="enableClearTextPlugin" id="a7b-zF-81T">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                    </subviews>
+                                                                                    <connections>
+                                                                                        <binding destination="-2" name="hidden" keyPath="useSSL" id="5649">
+                                                                                            <dictionary key="options">
+                                                                                                <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                                                                <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                                                                <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                                                                <integer key="NSNullPlaceholder" value="1"/>
+                                                                                                <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                                            </dictionary>
+                                                                                        </binding>
+                                                                                    </connections>
+                                                                                </customView>
+                                                                            </subviews>
+                                                                        </view>
+                                                                    </tabViewItem>
+                                                                    <tabViewItem label="Socket" identifier="2" id="4982">
+                                                                        <view key="view" id="4983">
+                                                                            <rect key="frame" x="10" y="33" width="420" height="371"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                            <subviews>
+                                                                                <customView id="5162">
+                                                                                    <rect key="frame" x="22" y="142" width="377" height="246"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <textField verticalHuggingPriority="750" id="5386">
+                                                                                            <rect key="frame" x="7" y="199" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Name:" id="5387">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter a nickname to use if adding to favorites. Optional." verticalHuggingPriority="750" id="5385">
+                                                                                            <rect key="frame" x="110" y="197" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5388">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="name" id="5400">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5401"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5219">
+                                                                                            <rect key="frame" x="7" y="37" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Socket:" id="5220">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the path to the socket file to use when connecting to MySQL.  Leave this field blank to use the default socket location" verticalHuggingPriority="750" id="5218">
+                                                                                            <rect key="frame" x="110" y="35" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5221">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="socket" id="5415">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5366"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5217">
+                                                                                            <rect key="frame" x="7" y="71" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Database:" id="5222">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Optionally enter a database to select after successfully connecting to the MySQL server" verticalHuggingPriority="750" id="5216">
+                                                                                            <rect key="frame" x="110" y="69" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5223">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="database" id="5413">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5365"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5215">
+                                                                                            <rect key="frame" x="7" y="105" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="5224">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the password to use when connecting to the MySQL server" verticalHuggingPriority="750" id="5214" customClass="NSSecureTextField">
+                                                                                            <rect key="frame" x="110" y="103" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5225">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="password" id="5234">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5364"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5213">
+                                                                                            <rect key="frame" x="7" y="139" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="5226">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the MySQL username to connect with" verticalHuggingPriority="750" id="5212">
+                                                                                            <rect key="frame" x="110" y="137" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5227">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="user" id="5231">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5363"/>
+                                                                                                <outlet property="nextKeyView" destination="5214" id="5463"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <button id="5720">
+                                                                                            <rect key="frame" x="108" y="7" width="251" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="check" title="Connect using SSL" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5721">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="updateSSLInterface:" target="-2" id="5723"/>
+                                                                                                <binding destination="-2" name="value" keyPath="useSSL" id="5722">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <customView id="5896" customClass="SPColorSelectorView">
+                                                                                            <rect key="frame" x="110" y="167" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <connections>
+                                                                                                <outlet property="delegate" destination="-2" id="5901"/>
+                                                                                            </connections>
+                                                                                        </customView>
+                                                                                    </subviews>
+                                                                                </customView>
+                                                                                <customView id="5688">
+                                                                                    <rect key="frame" x="22" y="7" width="377" height="135"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <button toolTip="Click to choose the SSL private key file to use when establishing a secure connection." verticalHuggingPriority="750" id="5695">
+                                                                                            <rect key="frame" x="328" y="80" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5700">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5717"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocationEnabled" id="5711">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5697">
+                                                                                            <rect key="frame" x="109" y="81" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5698">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.50403225419999997" alpha="1" colorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslKeyFileLocation" id="5714"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocation" id="5733">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5696">
+                                                                                            <rect key="frame" x="-3" y="83" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Key File:" id="5699">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the client SSL certificate file to use when establishing a secure connection." verticalHuggingPriority="750" id="5694">
+                                                                                            <rect key="frame" x="328" y="46" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5701">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5719"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocationEnabled" id="5707">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5693">
+                                                                                            <rect key="frame" x="109" y="47" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5702">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCertificateFileLocation" id="5708"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocation" id="5735">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5692">
+                                                                                            <rect key="frame" x="-3" y="49" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Certificate:" id="5703">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection." verticalHuggingPriority="750" id="5691">
+                                                                                            <rect key="frame" x="328" y="12" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5704">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5718"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocationEnabled" id="5715">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5690">
+                                                                                            <rect key="frame" x="109" y="13" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="5705">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCACertFileLocation" id="5712"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocation" id="5734">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5689">
+                                                                                            <rect key="frame" x="-3" y="15" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="CA Cert:" id="5706">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button id="XuK-Hs-TN4">
+                                                                                            <rect key="frame" x="108" y="114" width="252" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <string key="toolTip">This option will send your password as plain text, and should only be used with SSL connections. If you're unsure, contact your systems administrator.</string>
+                                                                                            <buttonCell key="cell" type="check" title="Enable ClearText plugin" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="m6P-hc-UDQ">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="enterEditMode:" target="-2" id="3pV-7l-qvc"/>
+                                                                                                <binding destination="-2" name="value" keyPath="enableClearTextPlugin" id="roX-Y5-zUm">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                    </subviews>
+                                                                                    <connections>
+                                                                                        <binding destination="-2" name="hidden" keyPath="useSSL" id="5710">
+                                                                                            <dictionary key="options">
+                                                                                                <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                                                                <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                                                                <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                                                                <integer key="NSNullPlaceholder" value="1"/>
+                                                                                                <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                                            </dictionary>
+                                                                                        </binding>
+                                                                                    </connections>
+                                                                                </customView>
+                                                                            </subviews>
+                                                                        </view>
+                                                                    </tabViewItem>
+                                                                    <tabViewItem label="SSH" identifier="Item 2" id="4985">
+                                                                        <view key="view" id="4986">
+                                                                            <rect key="frame" x="10" y="33" width="420" height="371"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                            <subviews>
+                                                                                <customView id="5166">
+                                                                                    <rect key="frame" x="22" y="-34" width="377" height="422"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <textField verticalHuggingPriority="750" id="5523">
+                                                                                            <rect key="frame" x="110" y="61" width="219" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5524">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.49596774580000003" alpha="1" colorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sshKeyLocation" id="5563">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sshKeyLocation" id="5570"/>
+                                                                                                <binding destination="-2" name="hidden" keyPath="sshKeyLocationEnabled" id="5562">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="1"/>
+                                                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5525">
+                                                                                            <rect key="frame" x="7" y="63" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SSH Key:" id="5526">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="hidden" keyPath="sshKeyLocationEnabled" id="5561">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="1"/>
+                                                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <button toolTip="Choose a custom SSH key file to use with this connection.  Standard locations like ~/.ssh are checked automatically." verticalHuggingPriority="750" id="5492">
+                                                                                            <rect key="frame" x="328" y="60" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="5493">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="5661"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sshKeyLocationEnabled" id="5551">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="5404">
+                                                                                            <rect key="frame" x="7" y="375" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Name:" id="5405">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter a nickname to use if adding to favorites. Optional." verticalHuggingPriority="750" id="5403">
+                                                                                            <rect key="frame" x="110" y="373" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5406">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="name" id="5411">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5414"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5291">
+                                                                                            <rect key="frame" x="7" y="29" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SSH Port:" id="5292">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the port to use when connecting to the SSH server.  The default SSH port is 22" verticalHuggingPriority="750" id="5290">
+                                                                                            <rect key="frame" x="110" y="27" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5293">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sshPort" id="5737">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5375"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5289">
+                                                                                            <rect key="frame" x="7" y="63" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SSH Password:" id="5294">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="hidden" keyPath="sshKeyLocationEnabled" id="5549">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5288" customClass="NSSecureTextField">
+                                                                                            <rect key="frame" x="110" y="61" width="219" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <string key="toolTip">Enter the password to use when connecting to the SSH server. NB: your SSH configuration is used, and public/private key pairs and other authentication methods will be used if available</string>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5295">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="hidden" keyPath="sshKeyLocationEnabled" id="5559"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sshPassword" id="5504">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5374"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5287">
+                                                                                            <rect key="frame" x="7" y="97" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SSH User:" id="5296">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the SSH username to connect with" verticalHuggingPriority="750" id="5286">
+                                                                                            <rect key="frame" x="110" y="95" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5297">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sshUser" id="5327">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5373"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5285">
+                                                                                            <rect key="frame" x="10" y="131" width="95" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SSH Host:" id="5298">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the hostname of the SSH server to tunnel via when connecting to the MySQL server" verticalHuggingPriority="750" id="5284">
+                                                                                            <rect key="frame" x="110" y="129" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5299">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sshHost" id="5323">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5372"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5273">
+                                                                                            <rect key="frame" x="10" y="179" width="95" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Port:" id="5274">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the port to use when connecting to the MySQL server.  The default MySQL port is 3306" verticalHuggingPriority="750" id="5272">
+                                                                                            <rect key="frame" x="110" y="177" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="3306" drawsBackground="YES" usesSingleLineMode="YES" id="5275">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="port" id="5419">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">3306</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5371"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5271">
+                                                                                            <rect key="frame" x="7" y="213" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Database:" id="5276">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Optionally enter a database to select after successfully connecting to the MySQL server" verticalHuggingPriority="750" id="5270">
+                                                                                            <rect key="frame" x="110" y="211" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" usesSingleLineMode="YES" id="5277">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="database" id="5412">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                        <string key="NSNullPlaceholder">optional</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5370"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5269">
+                                                                                            <rect key="frame" x="7" y="247" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="5278">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the password to use when connecting to the MySQL server" verticalHuggingPriority="750" id="5268" customClass="NSSecureTextField">
+                                                                                            <rect key="frame" x="110" y="245" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5279">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="password" id="5311">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5369"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5267">
+                                                                                            <rect key="frame" x="7" y="281" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="5280">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField toolTip="Enter the MySQL username to connect with" verticalHuggingPriority="750" id="5266">
+                                                                                            <rect key="frame" x="110" y="279" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5281">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="user" id="5307">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5368"/>
+                                                                                                <outlet property="nextKeyView" destination="5268" id="5465"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5265">
+                                                                                            <rect key="frame" x="7" y="315" width="98" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="MySQL Host:" id="5282">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="5264">
+                                                                                            <rect key="frame" x="110" y="313" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <string key="toolTip">Enter the hostname of the MySQL server you want to connect to.  Enter 127.0.0.1 to connect to a server running on the machine you are tunnelling to</string>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="5283">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="host" id="5303">
+                                                                                                    <dictionary key="options">
+                                                                                                        <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <outlet property="delegate" destination="-2" id="5367"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <customView id="5898" customClass="SPColorSelectorView">
+                                                                                            <rect key="frame" x="110" y="343" width="247" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <connections>
+                                                                                                <outlet property="delegate" destination="-2" id="5902"/>
+                                                                                            </connections>
+                                                                                        </customView>
+                                                                                        <button id="FtV-HG-DIU">
+                                                                                            <rect key="frame" x="108" y="3" width="251" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="check" title="Connect using SSL" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="w3N-9r-DzN">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="updateSSLInterface:" target="-2" id="KEh-s5-TWL"/>
+                                                                                                <binding destination="-2" name="value" keyPath="useSSL" id="WuC-tH-Z8g">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                    </subviews>
+                                                                                </customView>
+                                                                                <customView id="9t3-JG-c1l">
+                                                                                    <rect key="frame" x="21" y="-168" width="377" height="141"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <subviews>
+                                                                                        <button toolTip="Click to choose the SSL private key file to use when establishing a secure connection." verticalHuggingPriority="750" id="vPP-gd-c4a">
+                                                                                            <rect key="frame" x="328" y="80" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="OCU-fz-H9W">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="zge-vf-RDs"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocationEnabled" id="AQO-79-Qoa">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="hLW-S6-RZ9">
+                                                                                            <rect key="frame" x="109" y="81" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="wO6-xE-Gjg">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.50403225419999997" alpha="1" colorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslKeyFileLocation" id="1dY-ya-XZT"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslKeyFileLocation" id="HxQ-8U-qCi">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="Mkf-Q4-7vt">
+                                                                                            <rect key="frame" x="-3" y="83" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Key File:" id="xGU-pV-iYc">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the client SSL certificate file to use when establishing a secure connection." verticalHuggingPriority="750" id="VqZ-mo-IXW">
+                                                                                            <rect key="frame" x="328" y="46" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="dlS-N8-67W">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="Cyu-po-GQE"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocationEnabled" id="Ccl-JC-0KZ">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="3Y2-Rj-0be">
+                                                                                            <rect key="frame" x="109" y="47" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="ldB-Kc-oTh">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCertificateFileLocation" id="aQT-Hc-RZK">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCertificateFileLocation" id="aUS-Id-i02"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="zor-qs-az3">
+                                                                                            <rect key="frame" x="-3" y="49" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Certificate:" id="m4Z-qz-MVB">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button toolTip="Click to choose the SSL Certificate Authority certificate to verify the peer against when establishing a secure connection." verticalHuggingPriority="750" id="7eD-3o-HAJ">
+                                                                                            <rect key="frame" x="328" y="12" width="29" height="24"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="key-icon" imagePosition="overlaps" alignment="center" alternateImage="key-icon-alternate" borderStyle="border" inset="2" id="XZJ-kZ-hgG">
+                                                                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="chooseKeyLocation:" target="-2" id="cQ2-mu-0Ph"/>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocationEnabled" id="SW6-dc-cub">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <textField verticalHuggingPriority="750" id="7nJ-pZ-buy">
+                                                                                            <rect key="frame" x="109" y="13" width="220" height="22"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" lineBreakMode="truncatingHead" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="none set" drawsBackground="YES" id="30l-FF-qhV">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                            <connections>
+                                                                                                <binding destination="-2" name="value" keyPath="sslCACertFileLocation" id="bez-TY-JVB">
+                                                                                                    <dictionary key="options">
+                                                                                                        <string key="NSNullPlaceholder">none set</string>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                                <binding destination="-2" name="toolTip" keyPath="sslCACertFileLocation" id="s1j-iY-B0W"/>
+                                                                                            </connections>
+                                                                                        </textField>
+                                                                                        <textField verticalHuggingPriority="750" id="XLC-w6-o5W">
+                                                                                            <rect key="frame" x="-3" y="15" width="107" height="17"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="CA Cert:" id="QTm-ne-rcS">
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                        <button id="APB-vY-pvN">
+                                                                                            <rect key="frame" x="108" y="109" width="252" height="18"/>
+                                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                            <string key="toolTip">This option will send your password as plain text, and should only be used with SSL connections. If you're unsure, contact your systems administrator.</string>
+                                                                                            <buttonCell key="cell" type="check" title="Enable ClearText plugin" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="ZVr-7u-19q">
+                                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                                <font key="font" metaFont="system"/>
+                                                                                            </buttonCell>
+                                                                                            <connections>
+                                                                                                <action selector="enterEditMode:" target="-2" id="zs8-sk-DtD"/>
+                                                                                                <binding destination="-2" name="value" keyPath="enableClearTextPlugin" id="2ZJ-2U-CFV">
+                                                                                                    <dictionary key="options">
+                                                                                                        <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                                                        <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                                                        <integer key="NSNullPlaceholder" value="0"/>
+                                                                                                    </dictionary>
+                                                                                                </binding>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                    </subviews>
+                                                                                    <connections>
+                                                                                        <binding destination="-2" name="hidden" keyPath="useSSL" id="6oe-5y-dVM">
+                                                                                            <dictionary key="options">
+                                                                                                <integer key="NSMultipleValuesPlaceholder" value="1"/>
+                                                                                                <integer key="NSNoSelectionPlaceholder" value="1"/>
+                                                                                                <integer key="NSNotApplicablePlaceholder" value="1"/>
+                                                                                                <integer key="NSNullPlaceholder" value="1"/>
+                                                                                                <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                                            </dictionary>
+                                                                                        </binding>
+                                                                                    </connections>
+                                                                                </customView>
+                                                                            </subviews>
+                                                                        </view>
+                                                                    </tabViewItem>
+                                                                </tabViewItems>
+                                                                <connections>
+                                                                    <binding destination="-2" name="selectedIndex" keyPath="type" id="4992"/>
+                                                                    <outlet property="delegate" destination="-2" id="5165"/>
+                                                                </connections>
+                                                            </tabView>
+                                                        </subviews>
+                                                    </customView>
+                                                </subviews>
+                                            </customView>
+                                        </subviews>
+                                    </clipView>
+                                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="5590">
+                                        <rect key="frame" x="0.0" y="466" width="663" height="15"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                    </scroller>
+                                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="5589">
+                                        <rect key="frame" x="663" y="0.0" width="16" height="580"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                    </scroller>
+                                </scrollView>
+                                <textField verticalHuggingPriority="750" id="5154">
+                                    <rect key="frame" x="17" y="489" width="647" height="17"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Enter connection details below, or choose a favorite" id="5155">
+                                        <font key="font" metaFont="systemBold"/>
+                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                            </subviews>
+                        </view>
+                    </subviews>
+                    <holdingPriorities>
+                        <real value="250"/>
+                        <real value="250"/>
+                    </holdingPriorities>
+                    <connections>
+                        <outlet property="additionalDragHandleView" destination="5858" id="5860"/>
+                        <outlet property="delegate" destination="-2" id="5861"/>
+                    </connections>
+                </splitView>
+            </subviews>
+        </customView>
+        <window title="Error Detail" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="5431" userLabel="Error Detail HUD" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="439" y="291" width="580" height="320"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1178"/>
+            <value key="minSize" type="size" width="100" height="100"/>
+            <view key="contentView" id="5432">
+                <rect key="frame" x="0.0" y="0.0" width="580" height="320"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="5433">
+                        <rect key="frame" x="1" y="20" width="578" height="293"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dhh-q9-14d">
+                            <rect key="frame" x="0.0" y="0.0" width="578" height="293"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                            <subviews>
+                                <textView editable="NO" drawsBackground="NO" importsGraphics="NO" verticallyResizable="YES" id="5434">
+                                    <rect key="frame" x="0.0" y="0.0" width="578" height="293"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <color key="textColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <size key="minSize" width="578" height="293"/>
+                                    <size key="maxSize" width="1156" height="10000000"/>
+                                    <attributedString key="textStorage">
+                                        <fragment content="Lorem ipsum dolor sit er ">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" metaFont="label"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content="elit">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" size="10" name="LucidaGrande-Bold"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content=" lamet, ">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" metaFont="label"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content="consectetaur">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" size="10" name="LucidaGrande-Bold"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content=" cillium adipisicing pecu, sed do ">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" metaFont="label"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content="eiusmod">
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" size="10" name="LucidaGrande-Bold"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment>
+                                            <mutableString key="content"> tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum Et harumd und lookum like Greek to me, dereud facilis est er expedit distinct. Nam liber te conscient to factor tum poen legum odioque civiuda</mutableString>
+                                            <attributes>
+                                                <color key="NSColor" red="0.90196078999999996" green="0.90196078999999996" blue="0.90196078999999996" alpha="1" colorSpace="calibratedRGB"/>
+                                                <font key="NSFont" metaFont="label"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                    <tabStops>
+                                                        <textTab alignment="left" location="0.0">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="56">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="112">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="168">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="224">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="280">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="336">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="392">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="448">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="504">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="560">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="616">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="672">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="728">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="784">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="840">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="896">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="952">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1008">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1064">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1120">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1176">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1232">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1288">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1344">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1400">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1456">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1512">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1568">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1624">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1680">
+                                                            <options/>
+                                                        </textTab>
+                                                        <textTab alignment="left" location="1736">
+                                                            <options/>
+                                                        </textTab>
+                                                    </tabStops>
+                                                </paragraphStyle>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <size key="minSize" width="578" height="293"/>
+                                    <size key="maxSize" width="1156" height="10000000"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="-2" id="5462"/>
+                                    </connections>
+                                </textView>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="5435">
+                            <rect key="frame" x="-100" y="-100" width="87" height="18"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" arrowsPosition="none" horizontal="NO" id="5436">
+                            <rect key="frame" x="566" y="0.0" width="12" height="293"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="5461"/>
+            </connections>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="5455"/>
+        <customView id="5576" userLabel="SSH Key Selection Help">
+            <rect key="frame" x="0.0" y="0.0" width="579" height="83"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="5577">
+                    <rect key="frame" x="2" y="42" width="575" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" id="5578">
+                        <font key="font" metaFont="system"/>
+                        <string key="title">Choose a custom SSH key file to use with this connection. Note that standard locations like ~/.ssh are checked automatically, as are any files in your SSH configuration.</string>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="5748">
+                    <rect key="frame" x="14" y="14" width="273" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show hidden files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5749">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateKeyLocationFileVisibility:" target="-2" id="5755"/>
+                        <binding destination="5455" name="value" keyPath="values.KeySelectionHiddenFilesVisibility" id="5754">
+                            <dictionary key="options">
+                                <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                <integer key="NSNullPlaceholder" value="0"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </button>
+            </subviews>
+        </customView>
+        <customView id="5668" userLabel="SSL Key File Selection Help">
+            <rect key="frame" x="0.0" y="0.0" width="579" height="66"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="5669">
+                    <rect key="frame" x="2" y="42" width="575" height="17"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" title="Please select the SSL key file to use when establishing a secure connection." id="5670">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="5756">
+                    <rect key="frame" x="14" y="14" width="273" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show hidden files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5757">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateKeyLocationFileVisibility:" target="-2" id="5759"/>
+                        <binding destination="5455" name="value" keyPath="values.KeySelectionHiddenFilesVisibility" id="5758">
+                            <dictionary key="options">
+                                <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                <integer key="NSNullPlaceholder" value="0"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </button>
+            </subviews>
+        </customView>
+        <customView id="5683" userLabel="SSL Certificate File Selection Help">
+            <rect key="frame" x="0.0" y="0.0" width="599" height="66"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="5684">
+                    <rect key="frame" x="6" y="42" width="576" height="17"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" title="Please select the client SSL certificate file to use when establishing a secure connection." id="5685">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="5760">
+                    <rect key="frame" x="14" y="14" width="273" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show hidden files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5761">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateKeyLocationFileVisibility:" target="-2" id="5763"/>
+                        <binding destination="5455" name="value" keyPath="values.KeySelectionHiddenFilesVisibility" id="5762">
+                            <dictionary key="options">
+                                <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                <integer key="NSNullPlaceholder" value="0"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </button>
+            </subviews>
+        </customView>
+        <customView id="5680" userLabel="SSL CA Cert File Selection Help">
+            <rect key="frame" x="0.0" y="0.0" width="579" height="83"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="5681">
+                    <rect key="frame" x="2" y="42" width="575" height="34"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" id="5682">
+                        <font key="font" metaFont="system"/>
+                        <string key="title">Please select the client SSL Certificate Authority certificate to use when establishing a secure connection.  This must be the same as the server CA certificate.</string>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="5764">
+                    <rect key="frame" x="14" y="14" width="273" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show hidden files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5765">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateKeyLocationFileVisibility:" target="-2" id="5767"/>
+                        <binding destination="5455" name="value" keyPath="values.KeySelectionHiddenFilesVisibility" id="5766">
+                            <dictionary key="options">
+                                <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                <integer key="NSNullPlaceholder" value="0"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </button>
+            </subviews>
+        </customView>
+        <menu id="5788" userLabel="Context Menu">
+            <items>
+                <menuItem title="Rename" id="5795">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="renameNode:" target="-2" id="5819"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Remove" id="5794">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="removeNode:" target="-2" id="5802"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="5791"/>
+                <menuItem title="Duplicate" id="5789">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="duplicateFavorite:" target="-2" id="5803"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Make Default" id="5790">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="makeSelectedFavoriteDefault:" target="-2" id="5804"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="5793"/>
+                <menuItem title="Export..." id="5792">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="exportFavorites:" target="-2" id="5805"/>
+                    </connections>
+                </menuItem>
+            </items>
+            <connections>
+                <outlet property="delegate" destination="-2" id="5818"/>
+            </connections>
+        </menu>
+        <customView id="5796" userLabel="AccessoryView">
+            <rect key="frame" x="0.0" y="0.0" width="365" height="52"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="5797">
+                    <rect key="frame" x="-3" y="12" width="371" height="34"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="For security reasons, your connection favorite passwords are not included in the export." id="5798">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+        </customView>
+    </objects>
+    <resources>
+        <image name="button_action" width="32" height="23"/>
+        <image name="button_add" width="32" height="23"/>
+        <image name="button_add_folder" width="32" height="23"/>
+        <image name="button_bar_handle" width="15" height="23"/>
+        <image name="button_bar_spacer" width="10" height="23"/>
+        <image name="key-icon" width="16" height="9"/>
+        <image name="key-icon-alternate" width="16" height="9"/>
+    </resources>
+</document>

--- a/Source/SPConnectionController.h
+++ b/Source/SPConnectionController.h
@@ -83,6 +83,7 @@
 	
 	// SSL details
 	NSInteger useSSL;
+	NSInteger enableClearTextPlugin;
 	NSInteger sslKeyFileLocationEnabled;
 	NSString *sslKeyFileLocation;
 	NSInteger sslCertificateFileLocationEnabled;
@@ -193,6 +194,7 @@
 @property (readwrite, retain) NSString *socket;
 @property (readwrite, retain) NSString *port;
 @property (readwrite, assign) NSInteger useSSL;
+@property (readwrite, assign) NSInteger enableClearTextPlugin;
 @property (readwrite, assign) NSInteger colorIndex;
 @property (readwrite, assign) NSInteger sslKeyFileLocationEnabled;
 @property (readwrite, retain) NSString *sslKeyFileLocation;

--- a/Source/SPConnectionController.m
+++ b/Source/SPConnectionController.m
@@ -135,6 +135,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 @synthesize port;
 @synthesize colorIndex;
 @synthesize useSSL;
+@synthesize enableClearTextPlugin;
 @synthesize sslKeyFileLocationEnabled;
 @synthesize sslKeyFileLocation;
 @synthesize sslCertificateFileLocationEnabled;
@@ -600,8 +601,17 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 {
 #ifndef SP_CODA
 	[self _startEditingConnection];
+	[self _updateClearTextPluginOption];
 	[self resizeTabViewToConnectionType:[self type] animating:YES];
 #endif
+}
+
+/**
+ * Sets editing mode
+ */
+- (IBAction)enterEditMode:(id)sender
+{
+	[self _startEditingConnection];
 }
 
 /**
@@ -754,6 +764,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	
 	// SSL details
 	[self setUseSSL:([fav objectForKey:SPFavoriteUseSSLKey] ? [[fav objectForKey:SPFavoriteUseSSLKey] intValue] : NSOffState)];
+	[self setEnableClearTextPlugin:([fav objectForKey:SPFavoriteEnableClearTextPluginKey] ? [[fav objectForKey:SPFavoriteEnableClearTextPluginKey] intValue] : NSOffState)];
 	[self setSslKeyFileLocationEnabled:([fav objectForKey:SPFavoriteSSLKeyFileLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSLKeyFileLocationEnabledKey] intValue] : NSOffState)];
 	[self setSslKeyFileLocation:([fav objectForKey:SPFavoriteSSLKeyFileLocationKey] ? [fav objectForKey:SPFavoriteSSLKeyFileLocationKey] : @"")];
 	[self setSslCertificateFileLocationEnabled:([fav objectForKey:SPFavoriteSSLCertificateFileLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSLCertificateFileLocationEnabledKey] intValue] : NSOffState)];
@@ -902,6 +913,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 						@(NSOffState),
 						@(NSOffState),
 						@(NSOffState),
+						@(NSOffState),
 						@"",
 						@"",
 						@"",
@@ -919,7 +931,8 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 					 SPFavoriteUserKey,
 					 SPFavoriteColorIndexKey,
 					 SPFavoritePortKey, 
-					 SPFavoriteUseSSLKey, 
+					 SPFavoriteUseSSLKey,
+					 SPFavoriteEnableClearTextPluginKey,
 					 SPFavoriteSSLKeyFileLocationEnabledKey,
 					 SPFavoriteSSLCertificateFileLocationEnabledKey, 
 					 SPFavoriteSSLCACertFileLocationEnabledKey, 
@@ -1323,6 +1336,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	[theFavorite setObject:[NSNumber numberWithInteger:[self colorIndex]] forKey:SPFavoriteColorIndexKey];
 	// SSL details
 	[theFavorite setObject:[NSNumber numberWithInteger:[self useSSL]] forKey:SPFavoriteUseSSLKey];
+	[theFavorite setObject:[NSNumber numberWithInteger:[self enableClearTextPlugin]] forKey:SPFavoriteEnableClearTextPluginKey];
 	[theFavorite setObject:[NSNumber numberWithInteger:[self sslKeyFileLocationEnabled]] forKey:SPFavoriteSSLKeyFileLocationEnabledKey];
 	if ([self sslKeyFileLocation]) {
 		[theFavorite setObject:[self sslKeyFileLocation] forKey:SPFavoriteSSLKeyFileLocationKey];
@@ -1991,6 +2005,17 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	if (sshTunnel) [sshTunnel setConnectionStateChangeSelector:nil delegate:nil], SPClear(sshTunnel);
 }
 
+/**
+ * Forces ClearText plugin option to be turned off if the connection does not use SSL
+ */
+- (void) _updateClearTextPluginOption
+{
+	if (!useSSL) {
+		[self setEnableClearTextPlugin:useSSL];
+	}
+
+}
+
 #pragma mark -
 
 - (void)dealloc
@@ -2009,6 +2034,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	[self removeObserver:self forKeyPath:SPFavoriteSocketKey];
 	[self removeObserver:self forKeyPath:SPFavoritePortKey];
 	[self removeObserver:self forKeyPath:SPFavoriteUseSSLKey];
+	[self removeObserver:self forKeyPath:SPFavoriteEnableClearTextPluginKey];
 	[self removeObserver:self forKeyPath:SPFavoriteSSHHostKey];
 	[self removeObserver:self forKeyPath:SPFavoriteSSHUserKey];
 	[self removeObserver:self forKeyPath:SPFavoriteSSHPortKey];

--- a/Source/SPConnectionControllerInitializer.m
+++ b/Source/SPConnectionControllerInitializer.m
@@ -253,6 +253,11 @@ static NSString *SPConnectionViewNibName = @"ConnectionView";
 			  options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) 
 			  context:NULL];
 	
+	[self addObserver:self
+		   forKeyPath:SPFavoriteEnableClearTextPluginKey
+			  options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew)
+			  context:NULL];
+	
 	[self addObserver:self 
 		   forKeyPath:SPFavoriteSSHHostKey 
 			  options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) 

--- a/Source/SPConnectionHandler.m
+++ b/Source/SPConnectionHandler.m
@@ -146,6 +146,8 @@ static NSString *SPLocalhostAddress = @"127.0.0.1";
 			[mySQLConnection setSslCACertificatePath:[self sslCACertFileLocation]];
 		}
 		
+		[mySQLConnection setEnableClearTextPlugin:[self enableClearTextPlugin]];
+		
 		NSString *userSSLCipherList = [prefs stringForKey:SPSSLCipherListKey];
 		if(userSSLCipherList) {
 			//strip out disabled ciphers (e.g. in "foo:bar:--:baz")

--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -499,6 +499,7 @@ extern NSString *SPFavoriteSSHUserKey;
 extern NSString *SPFavoriteSSHKeyLocationEnabledKey;
 extern NSString *SPFavoriteSSHKeyLocationKey;
 extern NSString *SPFavoriteUseSSLKey;
+extern NSString *SPFavoriteEnableClearTextPluginKey;
 extern NSString *SPFavoriteSSLKeyFileLocationEnabledKey;
 extern NSString *SPFavoriteSSLKeyFileLocationKey;
 extern NSString *SPFavoriteSSLCertificateFileLocationEnabledKey;

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -308,6 +308,7 @@ NSString *SPFavoriteSSHUserKey                           = @"sshUser";
 NSString *SPFavoriteSSHKeyLocationEnabledKey             = @"sshKeyLocationEnabled";
 NSString *SPFavoriteSSHKeyLocationKey                    = @"sshKeyLocation";
 NSString *SPFavoriteUseSSLKey                            = @"useSSL";
+NSString *SPFavoriteEnableClearTextPluginKey             = @"enableClearTextPlugin";
 NSString *SPFavoriteSSLKeyFileLocationEnabledKey         = @"sslKeyFileLocationEnabled";
 NSString *SPFavoriteSSLKeyFileLocationKey                = @"sslKeyFileLocation";
 NSString *SPFavoriteSSLCertificateFileLocationEnabledKey = @"sslCertificateFileLocationEnabled";


### PR DESCRIPTION
Adds support to the ClearText plugin, and only allows such option to be used over SSL connections.

It is my understanding the choice of using the ClearText plugin is an organizational one, and also that even though some SSL misconfigurations can lead to the password being easily exposed, adding this feature to the software adds value to the tool.