### PR TITLE
Bugfix: mysql 5.8 crashes upon database selection / table selection

### DIFF
--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -5705,7 +5705,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 		}
 
 		if(userTerminated) {
-			[SPTooltip showWithObject:NSLocalizedString(@"URL scheme command was terminated by user", @"URL scheme command was terminated by user") atLocation:[NSApp mouseLocation]];
+			[SPTooltip showWithObject:NSLocalizedString(@"URL scheme command was terminated by user", @"URL scheme command was terminated by user") atLocation:[NSEvent mouseLocation]];
 			status = @"1";
 		}
 

--- a/Source/SPTableInfo.m
+++ b/Source/SPTableInfo.m
@@ -191,7 +191,10 @@
 					[numberFormatter stringFromNumber:[NSNumber numberWithLongLong:[[tableStatus objectForKey:@"Rows"] longLongValue]]]]];
 			}
 
-			[info addObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSString stringForByteSize:[[tableStatus objectForKey:@"Data_length"] longLongValue]]]];
+			NSString *dl = [tableStatus objectForKey:@"Data_length"];
+			dl = dl && ![dl isEqual:[NSNull null]] ? dl : nil;
+			
+			[info addObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSString stringForByteSize:[dl longLongValue]]]];
 			NSString *tableEnc = [tableDataInstance tableEncoding];
 			NSString *tableColl = [tableStatus objectForKey:@"Collation"];
 			if([tableColl length]) {

--- a/Source/SPTablesList.m
+++ b/Source/SPTablesList.m
@@ -237,8 +237,12 @@ static NSString *SPDuplicateTable = @"SPDuplicateTable";
 				[tableTypes addObject:[NSNumber numberWithInteger:SPTableTypeTable]];
 			}
 		} else {
+			NSString *bTableType = nil;
+			
 			for (NSArray *eachRow in theResult) {
 
+				bTableType = [[NSString alloc] initWithData:[eachRow objectAtIndex:1] encoding:NSUTF8StringEncoding];
+				
 				// Due to encoding problems it can be the case that [resultRow objectAtIndex:0]
 				// return NSNull, thus catch that case for safety reasons
 				id tableName = [eachRow objectAtIndex:0];
@@ -246,8 +250,8 @@ static NSString *SPDuplicateTable = @"SPDuplicateTable";
 					tableName = @"...";
 				}
 				[tables addObject:tableName];
-
-				if ([[eachRow objectAtIndex:1] isEqualToString:@"VIEW"]) {
+				
+				if ([bTableType isEqualToString:@"VIEW"]) {
 					[tableTypes addObject:[NSNumber numberWithInteger:SPTableTypeView]];
 					tableListContainsViews = YES;
 				} else {


### PR DESCRIPTION
I've temporarily fixed a few issues while running the app under MySQL 5.8 beta.

I needed this quickly so please review what i've done as it might not be the best choices :) But it fixes the crashes and i can use the app again.

I had to transition to 5.8 because of an ugly unsolved issue under Mac OSX and MySQL <= 5.7 with the amount of open files (described scenario here: https://bugs.mysql.com/bug.php?id=79125).

Thanks for the nice app!