### PR TITLE
Added option to always show host and database name in tabs

### DIFF
--- a/Interfaces/English.lproj/Preferences.xib
+++ b/Interfaces/English.lproj/Preferences.xib
@@ -539,7 +539,7 @@ Gw
                 <button misplaced="YES" id="N5e-kW-TkI">
                     <rect key="frame" x="202" y="64" width="360" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Always show host and database name" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6OP-rw-8Xu">
+                    <buttonCell key="cell" type="check" title="Always show connection and database name" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6OP-rw-8Xu">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/Interfaces/English.lproj/Preferences.xib
+++ b/Interfaces/English.lproj/Preferences.xib
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="13F1507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="box content view" minToolsVersion="7.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SPPreferenceController">
@@ -18,7 +19,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="2074" userLabel="General" customClass="SPGeneralPreferencePane">
             <connections>
                 <outlet property="defaultFavoritePopup" destination="569" id="2079"/>
@@ -201,7 +202,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="eRr-LP-c79">
                             <rect key="frame" x="1" y="1" width="264" height="133"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" id="1774">
                                     <rect key="frame" x="0.0" y="0.0" width="264" height="133"/>
@@ -230,7 +231,6 @@ Gw
                                     </connections>
                                 </tableView>
                             </subviews>
-                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </clipView>
                         <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="1773">
                             <rect key="frame" x="-100" y="-100" width="223" height="15"/>
@@ -244,10 +244,10 @@ Gw
                             <outlet property="nextKeyView" destination="2253" id="2262"/>
                         </connections>
                     </scrollView>
-                    <box autoresizesSubviews="NO" title="Box" boxType="custom" borderType="line" id="2252">
+                    <box autoresizesSubviews="NO" boxType="custom" borderType="line" title="Box" id="2252">
                         <rect key="frame" x="-1" y="57" width="266" height="23"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                        <view key="contentView">
+                        <view key="contentView" id="EF2-sm-OPo">
                             <rect key="frame" x="1" y="1" width="264" height="21"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
@@ -294,22 +294,19 @@ Gw
                 <outlet property="initialFirstResponder" destination="1774" id="1819"/>
             </connections>
         </window>
-        <customView id="17" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="280"/>
+        <customView misplaced="YES" id="17" userLabel="General">
+            <rect key="frame" x="0.0" y="0.0" width="580" height="317"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <userGuides>
                 <userLayoutGuide location="195" affinity="minX"/>
             </userGuides>
             <subviews>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1420">
-                    <rect key="frame" x="202" y="204" width="360" height="5"/>
+                <box verticalHuggingPriority="750" boxType="separator" id="1420">
+                    <rect key="frame" x="202" y="241" width="360" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <textField verticalHuggingPriority="750" id="1419">
-                    <rect key="frame" x="17" y="175" width="182" height="17"/>
+                    <rect key="frame" x="17" y="212" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Default View:" id="1421">
                         <font key="font" metaFont="system"/>
@@ -318,11 +315,11 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" id="1418">
-                    <rect key="frame" x="201" y="169" width="254" height="26"/>
+                    <rect key="frame" x="201" y="206" width="254" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Last Used" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1449" id="1422">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="1423">
                             <items>
                                 <menuItem title="Last Used" state="on" id="1449">
@@ -354,7 +351,7 @@ Gw
                         <binding destination="117" name="selectedTag" keyPath="values.DefaultViewMode" id="1464"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" id="790">
+                <textField verticalHuggingPriority="750" misplaced="YES" id="790">
                     <rect key="frame" x="247" y="23" width="316" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="queries (100 max)" id="791">
@@ -363,7 +360,7 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" verticalHuggingPriority="750" id="787">
+                <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" verticalHuggingPriority="750" misplaced="YES" id="787">
                     <rect key="frame" x="203" y="20" width="38" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="20" drawsBackground="YES" usesSingleLineMode="YES" id="788">
@@ -381,7 +378,7 @@ Gw
                         <binding destination="117" name="value" keyPath="values.CustomQueryMaxHistoryItems" id="800"/>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" id="785">
+                <textField verticalHuggingPriority="750" misplaced="YES" id="785">
                     <rect key="frame" x="17" y="23" width="181" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Remember Last:" id="786">
@@ -390,29 +387,20 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="784">
-                    <rect key="frame" x="204" y="53" width="357" height="5"/>
+                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" id="784">
+                    <rect key="frame" x="204" y="88" width="357" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="582">
-                    <rect key="frame" x="204" y="108" width="358" height="5"/>
+                <box verticalHuggingPriority="750" boxType="separator" id="582">
+                    <rect key="frame" x="204" y="145" width="358" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="581">
-                    <rect key="frame" x="202" y="156" width="360" height="5"/>
+                <box verticalHuggingPriority="750" boxType="separator" id="581">
+                    <rect key="frame" x="202" y="193" width="360" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <button id="957">
-                    <rect key="frame" x="202" y="62" width="360" height="18"/>
+                    <rect key="frame" x="202" y="99" width="360" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display vertical grid lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="958">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -423,7 +411,7 @@ Gw
                     </connections>
                 </button>
                 <button id="579">
-                    <rect key="frame" x="202" y="84" width="360" height="18"/>
+                    <rect key="frame" x="202" y="121" width="360" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Use monospaced fonts" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="580">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -434,7 +422,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="577">
-                    <rect key="frame" x="17" y="127" width="182" height="17"/>
+                    <rect key="frame" x="17" y="164" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Default Encoding:" id="578">
                         <font key="font" metaFont="system"/>
@@ -443,7 +431,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="1465">
-                    <rect key="frame" x="17" y="85" width="182" height="17"/>
+                    <rect key="frame" x="17" y="122" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Table Views:" id="1466">
                         <font key="font" metaFont="system"/>
@@ -452,11 +440,11 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" id="569">
-                    <rect key="frame" x="201" y="236" width="254" height="26"/>
+                    <rect key="frame" x="201" y="273" width="254" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" autoenablesItems="NO" id="570">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" autoenablesItems="NO" id="571"/>
                     </popUpButtonCell>
                     <connections>
@@ -464,7 +452,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" id="568">
-                    <rect key="frame" x="11" y="242" width="187" height="17"/>
+                    <rect key="frame" x="11" y="279" width="187" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Default Favorite:" id="575">
                         <font key="font" metaFont="system"/>
@@ -473,7 +461,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button id="567">
-                    <rect key="frame" x="202" y="214" width="362" height="18"/>
+                    <rect key="frame" x="202" y="251" width="362" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Connect to default on startup" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="576">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -484,14 +472,14 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="201" y="121" width="254" height="26"/>
+                    <rect key="frame" x="201" y="158" width="254" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <popUpButtonCell key="cell" type="push" title="Autodetect" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="25">
+                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="25">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="26">
                             <items>
-                                <menuItem title="Autodetect" state="on" id="50"/>
+                                <menuItem title="Autodetect" id="50"/>
                                 <menuItem isSeparatorItem="YES" tag="-1" id="49">
                                     <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 </menuItem>
@@ -544,8 +532,32 @@ Gw
                         </binding>
                     </connections>
                 </popUpButton>
+                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" id="Rsa-kp-ipJ">
+                    <rect key="frame" x="203" y="53" width="357" height="5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                </box>
+                <button misplaced="YES" id="N5e-kW-TkI">
+                    <rect key="frame" x="202" y="64" width="360" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Always show host and database name" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6OP-rw-8Xu">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="117" name="value" keyPath="values.DisplayLongTabTitles" id="6614"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" misplaced="YES" id="gmk-1B-dCR">
+                    <rect key="frame" x="17" y="65" width="182" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Tab Titles:" id="5mD-F5-bPV">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
-            <point key="canvasLocation" x="230" y="459"/>
+            <point key="canvasLocation" x="230" y="477.5"/>
         </customView>
         <customView id="512" userLabel="Tables">
             <rect key="frame" x="0.0" y="0.0" width="580" height="319"/>
@@ -565,33 +577,21 @@ Gw
                         <binding destination="117" name="value" keyPath="values.NewFieldsAllowNulls" id="953"/>
                     </connections>
                 </button>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="554">
+                <box verticalHuggingPriority="750" boxType="separator" id="554">
                     <rect key="frame" x="205" y="133" width="355" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="553">
+                <box verticalHuggingPriority="750" boxType="separator" id="553">
                     <rect key="frame" x="205" y="172" width="355" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="552">
+                <box verticalHuggingPriority="750" boxType="separator" id="552">
                     <rect key="frame" x="205" y="227" width="355" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1492">
+                <box verticalHuggingPriority="750" boxType="separator" id="1492">
                     <rect key="frame" x="205" y="48" width="355" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <button id="535">
                     <rect key="frame" x="203" y="201" width="359" height="18"/>
@@ -720,12 +720,9 @@ Gw
                         <binding destination="117" name="value" keyPath="values.ReloadAfterRemovingRow" id="616"/>
                     </connections>
                 </button>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1467">
+                <box verticalHuggingPriority="750" boxType="separator" id="1467">
                     <rect key="frame" x="205" y="89" width="355" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <textField verticalHuggingPriority="750" id="1468">
                     <rect key="frame" x="17" y="65" width="182" height="17"/>
@@ -750,7 +747,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Only use additional queries for small tables" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="1474" id="1471">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="1472">
                             <items>
                                 <menuItem title="Never use additional queries for table row counts" id="1473"/>
@@ -800,8 +797,8 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1160"/>
                         <binding destination="117" name="value" keyPath="values.ConsoleEnableErrorLogging" id="1382"/>
+                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1160"/>
                     </connections>
                 </button>
                 <button id="1152">
@@ -812,8 +809,8 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1159"/>
                         <binding destination="117" name="value" keyPath="values.ConsoleEnableCustomQueryLogging" id="1381"/>
+                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1159"/>
                     </connections>
                 </button>
                 <button id="1150">
@@ -824,8 +821,8 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1158"/>
                         <binding destination="117" name="value" keyPath="values.ConsoleEnableImportExportLogging" id="1380"/>
+                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1158"/>
                     </connections>
                 </button>
                 <button id="1148">
@@ -836,8 +833,8 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1157"/>
                         <binding destination="117" name="value" keyPath="values.ConsoleEnableInterfaceLogging" id="1379"/>
+                        <binding destination="117" name="enabled" keyPath="values.ConsoleEnableLogging" id="1157"/>
                     </connections>
                 </button>
                 <button id="1143">
@@ -862,12 +859,9 @@ Gw
                         <binding destination="117" name="value" keyPath="values.ShowNoAffectedRowsError" id="632"/>
                     </connections>
                 </button>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1156">
+                <box verticalHuggingPriority="750" boxType="separator" id="1156">
                     <rect key="frame" x="202" y="136" width="360" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <button id="110">
                     <rect key="frame" x="202" y="208" width="360" height="18"/>
@@ -910,7 +904,7 @@ Line 2</string>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Weekly" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="604800" imageScaling="proportionallyDown" inset="2" selectedItem="1358" id="1354">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="1355">
                             <items>
                                 <menuItem title="Hourly" tag="3600" id="1356"/>
@@ -920,8 +914,8 @@ Line 2</string>
                         </menu>
                     </popUpButtonCell>
                     <connections>
-                        <binding destination="117" name="enabled" keyPath="values.SUEnableAutomaticChecks" id="1368"/>
                         <binding destination="331" name="selectedTag" keyPath="updateCheckInterval" id="1361"/>
+                        <binding destination="117" name="enabled" keyPath="values.SUEnableAutomaticChecks" id="1368"/>
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" id="1351">
@@ -933,12 +927,9 @@ Line 2</string>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1618">
+                <box verticalHuggingPriority="750" boxType="separator" id="1618">
                     <rect key="frame" x="204" y="72" width="356" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <textField verticalHuggingPriority="750" id="100">
                     <rect key="frame" x="201" y="49" width="362" height="17"/>
@@ -996,12 +987,9 @@ Line 2</string>
                         <binding destination="117" name="value" keyPath="values.SUSendProfileInfo" id="1624"/>
                     </connections>
                 </button>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1620">
+                <box verticalHuggingPriority="750" boxType="separator" id="1620">
                     <rect key="frame" x="204" y="135" width="356" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
             </subviews>
         </customView>
@@ -1009,26 +997,17 @@ Line 2</string>
             <rect key="frame" x="0.0" y="0.0" width="580" height="312"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="681">
+                <box verticalHuggingPriority="750" boxType="separator" id="681">
                     <rect key="frame" x="226" y="262" width="334" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="HWX-AV-xGx">
+                <box verticalHuggingPriority="750" boxType="separator" id="HWX-AV-xGx">
                     <rect key="frame" x="226" y="229" width="334" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="3Fg-G1-BWj">
+                <box verticalHuggingPriority="750" boxType="separator" id="3Fg-G1-BWj">
                     <rect key="frame" x="226" y="193" width="334" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <textField verticalHuggingPriority="750" id="676">
                     <rect key="frame" x="281" y="276" width="282" height="17"/>
@@ -1102,7 +1081,7 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundRect" title="Change…" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MhF-tS-nrE">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="controlContent"/>
+                        <font key="font" metaFont="cellTitle"/>
                     </buttonCell>
                     <connections>
                         <action selector="pickSSHClient:" target="2146" id="zcA-5j-KFq"/>
@@ -1129,13 +1108,13 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="M9x-3Q-tiD">
                         <rect key="frame" x="1" y="1" width="332" height="126"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" id="RuH-Yq-cdH">
                                 <rect key="frame" x="0.0" y="0.0" width="332" height="126"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn editable="NO" width="329" minWidth="40" maxWidth="1000" id="2w5-RF-2LR">
@@ -1158,7 +1137,6 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ZqJ-4c-bqV">
                         <rect key="frame" x="1" y="119" width="223" height="15"/>
@@ -1205,12 +1183,9 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                 <userLayoutGuide location="315" affinity="minX"/>
             </userGuides>
             <subviews>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="1085">
+                <box verticalHuggingPriority="750" boxType="separator" id="1085">
                     <rect key="frame" x="204" y="349" width="356" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
                 </box>
                 <textField verticalHuggingPriority="750" id="1083">
                     <rect key="frame" x="423" y="186" width="140" height="14"/>
@@ -1232,8 +1207,8 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                     </stepperCell>
                     <connections>
                         <action selector="takeFloatValueFrom:" target="1044" id="1114"/>
-                        <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1110"/>
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoHelpDelay" id="1100"/>
+                        <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1110"/>
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" id="1045">
@@ -1251,7 +1226,7 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                 <textField verticalHuggingPriority="750" id="1044">
                     <rect key="frame" x="370" y="184" width="29" height="19"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0.1" drawsBackground="YES" usesSingleLineMode="YES" id="1049">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title=".1" drawsBackground="YES" usesSingleLineMode="YES" id="1049">
                         <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#.0" alwaysShowsDecimalSeparator="YES" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="1" decimalSeparator="." groupingSeparator="" id="1050">
                             <nil key="negativeInfinitySymbol"/>
                             <nil key="positiveInfinitySymbol"/>
@@ -1264,8 +1239,8 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                     </textFieldCell>
                     <connections>
                         <action selector="takeFloatValueFrom:" target="1046" id="1113"/>
-                        <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1109"/>
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoHelpDelay" id="1104"/>
+                        <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1109"/>
                     </connections>
                 </textField>
                 <button hidden="YES" id="1043">
@@ -1526,7 +1501,7 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
                         <rect key="frame" x="1" y="1" width="220" height="286"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
                                 <rect key="frame" x="0.0" y="0.0" width="220" height="286"/>
@@ -1568,7 +1543,6 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="1684">
                         <rect key="frame" x="-100" y="-100" width="223" height="15"/>
@@ -1728,9 +1702,9 @@ Warning: If Sequel Pro and the server do not have at least one cipher suite in c
     </objects>
     <resources>
         <image name="NSAdvanced" width="32" height="32"/>
-        <image name="button_bar_spacer" width="10" height="29"/>
-        <image name="button_duplicate" width="33" height="23"/>
-        <image name="button_remove" width="32" height="23"/>
+        <image name="button_bar_spacer" width="11" height="23"/>
+        <image name="button_duplicate" width="30" height="22"/>
+        <image name="button_remove" width="30" height="22"/>
         <image name="reset" width="16" height="16"/>
     </resources>
 </document>

--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -389,6 +389,7 @@ extern NSString *SPResetAutoIncrementAfterDeletionOfAllRows;
 extern NSString *SPFavoriteColorList;
 extern NSString *SPDisplayBinaryDataAsHex;
 extern NSString *SPMonospacedFontSize;
+extern NSString *SPDisplayLongTabTitles;
 
 // Hidden Prefs
 extern NSString *SPPrintWarningRowLimit;

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -188,6 +188,7 @@ NSString *SPResetAutoIncrementAfterDeletionOfAllRows = @"ResetAutoIncrementAfter
 NSString *SPFavoriteColorList                    = @"FavoriteColorList";
 NSString *SPDisplayBinaryDataAsHex               = @"DisplayBinaryDataAsHex";
 NSString *SPMonospacedFontSize                   = @"MonospacedFontSize";
+NSString *SPDisplayLongTabTitles                 = @"DisplayLongTabTitles";
 
 // Hidden Prefs
 NSString *SPPrintWarningRowLimit                 = @"PrintWarningRowLimit";

--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -3866,6 +3866,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	SPDatabaseDocument *frontTableDocument = [parentWindowController selectedTableDocument];
 	
 	NSColor *tabColor = nil;
+	bool longTitles = [prefs boolForKey:SPDisplayLongTabTitles];
 
 	// Determine name details
 	NSString *pathName = @"";
@@ -3897,14 +3898,15 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 		[windowTitle appendString:[self name]];
 
 		// Also add to the non-front tabs if the host is different, not connected, or no db is selected
-		if ([[frontTableDocument name] isNotEqualTo:[self name]] || ![frontTableDocument getConnection] || ![self database]) {
+		if (longTitles || [[frontTableDocument name] isNotEqualTo:[self name]] || ![frontTableDocument getConnection] || ![self database]) {
 			[tabTitle appendString:[self name]];
 		}
 
 		// If a database is selected, add to the window - and other tabs if host is the same but db different or table is not set
 		if ([self database]) {
 			[windowTitle appendFormat:@"/%@", [self database]];
-			if (frontTableDocument == self
+			if (longTitles
+				|| frontTableDocument == self
 				|| ![frontTableDocument getConnection]
 				|| [[frontTableDocument name] isNotEqualTo:[self name]]
 				|| [[frontTableDocument database] isNotEqualTo:[self database]]
@@ -3928,7 +3930,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	[parentTabViewItem setColor:tabColor];
 	[parentWindowController updateTabBar];
 	
-	if ([parentWindowController selectedTableDocument] == self) {
+	if (frontTableDocument == self) {
 		[parentWindow setTitle:windowTitle];
 	}
 


### PR DESCRIPTION
This PR adds a checkbox in the Preferences window to always show connection and database names in the tab titles, to make it clearer what database or host you are connecting to in the case where you might have databases with the same name on different hosts.

As requested in #2748.