### PR TITLE
Add a 24-hour-format time token(s) for the custom export filename field

### DIFF
--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -414,6 +414,7 @@ extern NSString *SPFileNameYearTokenName;
 extern NSString *SPFileNameMonthTokenName;
 extern NSString *SPFileNameDayTokenName;
 extern NSString *SPFileNameTimeTokenName;
+extern NSString *SPFileName24HourTimeTokenName;
 extern NSString *SPFileNameFavoriteTokenName;
 extern NSString *SPFileNameTableTokenName;
 

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -206,15 +206,16 @@ NSString *SPImportClipboardTempFileNamePrefix    = @"/tmp/_SP_ClipBoard_Import_F
 NSString *SPLastExportSettings                   = @"LastExportSettings";
 
 // Export filename tokens
-NSString *SPFileNameDatabaseTokenName = @"database";
-NSString *SPFileNameHostTokenName     = @"host";
-NSString *SPFileNameDateTokenName     = @"date";
-NSString *SPFileNameYearTokenName     = @"year";
-NSString *SPFileNameMonthTokenName    = @"month";
-NSString *SPFileNameDayTokenName      = @"day";
-NSString *SPFileNameTimeTokenName     = @"time";
-NSString *SPFileNameFavoriteTokenName = @"favorite";
-NSString *SPFileNameTableTokenName    = @"table";
+NSString *SPFileNameDatabaseTokenName   = @"database";
+NSString *SPFileNameHostTokenName       = @"host";
+NSString *SPFileNameDateTokenName       = @"date";
+NSString *SPFileNameYearTokenName       = @"year";
+NSString *SPFileNameMonthTokenName      = @"month";
+NSString *SPFileNameDayTokenName        = @"day";
+NSString *SPFileNameTimeTokenName       = @"time";
+NSString *SPFileName24HourTimeTokenName = @"time24";
+NSString *SPFileNameFavoriteTokenName   = @"favorite";
+NSString *SPFileNameTableTokenName      = @"table";
 
 // Misc 
 NSString *SPContentFilters                       = @"ContentFilters";

--- a/Source/SPExportController.m
+++ b/Source/SPExportController.m
@@ -125,15 +125,16 @@ static const NSString *SPSQLExportDropEnabled       = @"SQLExportDropEnabled";
 		prefs = [NSUserDefaults standardUserDefaults];
 		
 		localizedTokenNames = [@{
-			SPFileNameHostTokenName:     NSLocalizedString(@"Host", @"export filename host token"),
-			SPFileNameDatabaseTokenName: NSLocalizedString(@"Database", @"export filename database token"),
-			SPFileNameTableTokenName:    NSLocalizedString(@"Table", @"table"),
-			SPFileNameDateTokenName:     NSLocalizedString(@"Date", @"export filename date token"),
-			SPFileNameYearTokenName:     NSLocalizedString(@"Year", @"export filename date token"),
-			SPFileNameMonthTokenName:    NSLocalizedString(@"Month", @"export filename date token"),
-			SPFileNameDayTokenName:      NSLocalizedString(@"Day", @"export filename date token"),
-			SPFileNameTimeTokenName:     NSLocalizedString(@"Time", @"export filename time token"),
-			SPFileNameFavoriteTokenName: NSLocalizedString(@"Favorite", @"export filename favorite name token")
+			SPFileNameHostTokenName:       NSLocalizedString(@"Host", @"export filename host token"),
+			SPFileNameDatabaseTokenName:   NSLocalizedString(@"Database", @"export filename database token"),
+			SPFileNameTableTokenName:      NSLocalizedString(@"Table", @"table"),
+			SPFileNameDateTokenName:       NSLocalizedString(@"Date", @"export filename date token"),
+			SPFileNameYearTokenName:       NSLocalizedString(@"Year", @"export filename date token"),
+			SPFileNameMonthTokenName:      NSLocalizedString(@"Month", @"export filename date token"),
+			SPFileNameDayTokenName:        NSLocalizedString(@"Day", @"export filename date token"),
+			SPFileNameTimeTokenName:       NSLocalizedString(@"Time", @"export filename time token"),
+			SPFileName24HourTimeTokenName: NSLocalizedString(@"24-Hour Time", @"export filename time token"),
+			SPFileNameFavoriteTokenName:   NSLocalizedString(@"Favorite", @"export filename favorite name token")
 		} retain];
 	}
 	

--- a/Source/SPExportFilenameUtilities.m
+++ b/Source/SPExportFilenameUtilities.m
@@ -126,6 +126,7 @@
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameMonthTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameDayTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameTimeTokenName],
+		[SPExportFileNameTokenObject tokenWithId:SPFileName24HourTimeTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameFavoriteTokenName],
 		(tableObject = [SPExportFileNameTokenObject tokenWithId:SPFileNameTableTokenName]),
 		nil
@@ -295,6 +296,9 @@
 				[dateFormatter setDateStyle:NSDateFormatterNoStyle];
 				[dateFormatter setTimeStyle:NSDateFormatterShortStyle];
 				[string appendString:[dateFormatter stringFromDate:[NSDate date]]];
+			}
+			else if ([tokenContent isEqualToString:SPFileName24HourTimeTokenName]) {
+				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil]];
 			}
 			else if ([tokenContent isEqualToString:SPFileNameFavoriteTokenName]) {
 				[string appendStringOrNil:[tableDocumentInstance name]];


### PR DESCRIPTION
**Feature Request: Add a time token for the custom export filename field that produces an alphabetizable replacement value regardless of the user's local time-format settings.**

The currently-implemented `time` token produces an output that is formatted according to the user's system settings — which is of course the "preferred" implementation (according to [Technical Q&A QA1480](https://developer.apple.com/library/content/qa/qa1480/_index.html)). However, in many cases, this produces a 12-hour-format output (e.g. `7:11 AM`), which is frustrating if you're trying to sort a list of exports by alphabetizing the filenames. This PR seeks to add an alternative time token option that always uses a full 24-hour format.