### PR TITLE
Exchange `24-Hour Time` token for individual `Hour`, `Minute`, and `Second` tokens

### DIFF
--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -414,7 +414,9 @@ extern NSString *SPFileNameYearTokenName;
 extern NSString *SPFileNameMonthTokenName;
 extern NSString *SPFileNameDayTokenName;
 extern NSString *SPFileNameTimeTokenName;
-extern NSString *SPFileName24HourTimeTokenName;
+extern NSString *SPFileNameHourTokenName;
+extern NSString *SPFileNameMinuteTokenName;
+extern NSString *SPFileNameSecondTokenName;
 extern NSString *SPFileNameFavoriteTokenName;
 extern NSString *SPFileNameTableTokenName;
 

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -213,7 +213,9 @@ NSString *SPFileNameYearTokenName       = @"year";
 NSString *SPFileNameMonthTokenName      = @"month";
 NSString *SPFileNameDayTokenName        = @"day";
 NSString *SPFileNameTimeTokenName       = @"time";
-NSString *SPFileName24HourTimeTokenName = @"time24";
+NSString *SPFileNameHourTokenName       = @"hour";
+NSString *SPFileNameMinuteTokenName     = @"minute";
+NSString *SPFileNameSecondTokenName     = @"second";
 NSString *SPFileNameFavoriteTokenName   = @"favorite";
 NSString *SPFileNameTableTokenName      = @"table";
 

--- a/Source/SPExportController.m
+++ b/Source/SPExportController.m
@@ -133,7 +133,9 @@ static const NSString *SPSQLExportDropEnabled       = @"SQLExportDropEnabled";
 			SPFileNameMonthTokenName:      NSLocalizedString(@"Month", @"export filename date token"),
 			SPFileNameDayTokenName:        NSLocalizedString(@"Day", @"export filename date token"),
 			SPFileNameTimeTokenName:       NSLocalizedString(@"Time", @"export filename time token"),
-			SPFileName24HourTimeTokenName: NSLocalizedString(@"24-Hour Time", @"export filename time token"),
+			SPFileNameHourTokenName:       NSLocalizedString(@"Hour", @"export filename time token"),
+			SPFileNameMinuteTokenName:     NSLocalizedString(@"Minute", @"export filename time token"),
+			SPFileNameSecondTokenName:     NSLocalizedString(@"Second", @"export filename time token"),
 			SPFileNameFavoriteTokenName:   NSLocalizedString(@"Favorite", @"export filename favorite name token")
 		} retain];
 	}

--- a/Source/SPExportFilenameUtilities.m
+++ b/Source/SPExportFilenameUtilities.m
@@ -126,7 +126,9 @@
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameMonthTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameDayTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameTimeTokenName],
-		[SPExportFileNameTokenObject tokenWithId:SPFileName24HourTimeTokenName],
+		[SPExportFileNameTokenObject tokenWithId:SPFileNameHourTokenName],
+		[SPExportFileNameTokenObject tokenWithId:SPFileNameMinuteTokenName],
+		[SPExportFileNameTokenObject tokenWithId:SPFileNameSecondTokenName],
 		[SPExportFileNameTokenObject tokenWithId:SPFileNameFavoriteTokenName],
 		(tableObject = [SPExportFileNameTokenObject tokenWithId:SPFileNameTableTokenName]),
 		nil
@@ -297,8 +299,14 @@
 				[dateFormatter setTimeStyle:NSDateFormatterShortStyle];
 				[string appendString:[dateFormatter stringFromDate:[NSDate date]]];
 			}
-			else if ([tokenContent isEqualToString:SPFileName24HourTimeTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil]];
+			else if ([tokenContent isEqualToString:SPFileNameHourTokenName]) {
+				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%H" timeZone:nil locale:nil]];
+			}
+			else if ([tokenContent isEqualToString:SPFileNameMinuteTokenName]) {
+				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%M" timeZone:nil locale:nil]];
+			}
+			else if ([tokenContent isEqualToString:SPFileNameSecondTokenName]) {
+				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%S" timeZone:nil locale:nil]];
 			}
 			else if ([tokenContent isEqualToString:SPFileNameFavoriteTokenName]) {
 				[string appendStringOrNil:[tableDocumentInstance name]];


### PR DESCRIPTION
This is a follow-up to #2852, adding the [improvement](https://github.com/sequelpro/sequelpro/pull/2852#issuecomment-320837725) of individual `Hour`, `Minute`, and `Second` tokens, in place of the originally proposed `24-Hour Time` token.

(This more closely imitates how the current token selection includes both a formatted `Date` as well as individual `Year`, `Month`, and `Day` components. It affords the user a bit more flexibility to include/exclude/rearrange the individual pieces in their filename.)