### PR TITLE
Issue fix #1383

### DIFF
--- a/Source/SPTableStructure.m
+++ b/Source/SPTableStructure.m
@@ -1036,6 +1036,10 @@ static inline SPFieldTypeHelp *MakeFieldTypeHelp(NSString *typeName,NSString *ty
 			else if (![defaultValue length] && ([fieldValidation isFieldTypeNumeric:theRowType] || [fieldValidation isFieldTypeDate:theRowType] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"BLOB"] || [theRowType isEqualToString:@"JSON"] || [fieldValidation isFieldTypeGeometry:theRowType])) {
 				;
 			}
+			//for ENUM field type
+			else if (([defaultValue length]==0) && [theRowType isEqualToString:@"ENUM"]) {
+				[queryString appendFormat:@" "];
+			}
 			// Otherwise, use the provided default
 			else {
 				[queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];


### PR DESCRIPTION
Issue fix #1383

Default value for ENUM type

If field has value NULL before changing it to NOT NULL values for NULL should be changed to other values to prevent error raising about “truncated data” by MySQL.
