### PR TITLE
Optionally sort tables descending when loading

### DIFF
--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -321,6 +321,7 @@ extern NSString *SPNullValue;
 extern NSString *SPGlobalResultTableFont;
 extern NSString *SPFilterTableDefaultOperator;
 extern NSString *SPFilterTableDefaultOperatorLastItems;
+extern NSString *SPTableSortDescendingInitially;
 
 // Favorites Prefpane
 extern NSString *SPFavorites;

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -112,6 +112,7 @@ NSString *SPNullValue                            = @"SPNullValue";
 NSString *SPGlobalResultTableFont                = @"GlobalResultTableFont";
 NSString *SPFilterTableDefaultOperator           = @"FilterTableDefaultOperator";
 NSString *SPFilterTableDefaultOperatorLastItems  = @"FilterTableDefaultOperatorLastItems";
+NSString *SPTableSortDescendingInitially		 = @"TableSortDescendingInitially";
 
 // Favorites Prefpane
 NSString *SPFavorites                            = @"favorites";

--- a/Source/SPTableContent.h
+++ b/Source/SPTableContent.h
@@ -135,7 +135,7 @@
 	NSUInteger tableRowsCount, previousTableRowsCount;
 	NSString *compareType;
 	NSNumber *sortCol;
-	BOOL isEditingRow, isEditingNewRow, isSavingRow, isDesc, setLimit;
+	BOOL isEditingRow, isEditingNewRow, isSavingRow, isDesc, setLimit, passedInitialSort;
 	BOOL isFiltered, isLimited, isInterruptedLoad, maxNumRowsIsEstimate;
 	NSUserDefaults *prefs;
 	NSInteger currentlyEditingRow, maxNumRows;

--- a/Source/SPTableContent.m
+++ b/Source/SPTableContent.m
@@ -348,6 +348,8 @@ static NSString *SPTableFilterSetDefaultOperator = @"SPTableFilterSetDefaultOper
 	// Init copyTable with necessary information for copying selected rows as SQL INSERT
 	[tableContentView setTableInstance:self withTableData:tableValues withColumns:dataColumns withTableName:selectedTable withConnection:mySQLConnection];
 
+	passedInitialSort = NO;
+
 	// Trigger a data refresh
 	[self loadTableValues];
 
@@ -835,6 +837,13 @@ static NSString *SPTableFilterSetDefaultOperator = @"SPTableFilterSetDefaultOper
 		isFiltered = YES;
 	} else {
 		isFiltered = NO;
+	}
+	
+	if (!passedInitialSort)
+	{
+		sortCol = @(0);
+		isDesc = YES;
+		passedInitialSort = YES;
 	}
 
 	// Add sorting details if appropriate

--- a/Source/SPTableContent.m
+++ b/Source/SPTableContent.m
@@ -839,7 +839,7 @@ static NSString *SPTableFilterSetDefaultOperator = @"SPTableFilterSetDefaultOper
 		isFiltered = NO;
 	}
 	
-	if (!passedInitialSort)
+	if (!passedInitialSort && [prefs boolForKey:SPTableSortDescendingInitially])
 	{
 		sortCol = @(0);
 		isDesc = YES;


### PR DESCRIPTION
I find myself always resorting the my tables to see the latest records on top.
In my fork I added a preference key to automate this behavior.

TableSortDescendingInitially = YES 

Not sure if this should be an UI option or just remain a hidden setting.