### PR TITLE
SPUserManager: fix crash with MariaDB 10.3

### DIFF
--- a/Models/SPUserManager.xcdatamodel/contents
+++ b/Models/SPUserManager.xcdatamodel/contents
@@ -21,6 +21,7 @@
         <attribute name="show_view_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="trigger_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="update_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="delete_history_priv" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="userManager" optional="YES" transient="YES" syncable="YES"/>
         <relationship name="user" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="SPUser" inverseName="schema_privileges" inverseEntity="SPUser" indexed="YES" syncable="YES"/>
     </entity>
@@ -68,6 +69,7 @@
         <attribute name="super_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="trigger_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="update_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="delete_history_priv" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="user" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="userManager" optional="YES" transient="YES" syncable="YES"/>
         <relationship name="children" optional="YES" toMany="YES" minCount="1" deletionRule="Cascade" destinationEntity="SPUser" inverseName="parent" inverseEntity="SPUser" indexed="YES" syncable="YES"/>


### PR DESCRIPTION
Patch by @Muffinman in #3167 for the MariaDB 10.3.5 change at https://github.com/MariaDB/server/commit/f7621f17bd (Truncate_versioning_priv->Delete_history_priv).

Closes #2982, closes #3139, closes #3133 and closes #3167.