### PR TITLE
Default visible content filtering

### DIFF
--- a/Source/SPRuleFilterController.m
+++ b/Source/SPRuleFilterController.m
@@ -1325,11 +1325,20 @@ BOOL SerIsGroup(NSDictionary *dict)
 
 		NSArray *values = [in objectForKey:SerFilterExprValues];
 
+
+		NSString *firstValue = [values objectOrNilAtIndex:0];
+		NSString *secondValue = [values objectOrNilAtIndex:1];
+		
+		// Check to see if all input values are emtpy - if so, no intended filtering to be done
+		if(!((firstValue != nil && [firstValue length] > 0) || (secondValue != nil && [secondValue length] > 0))) {
+			return;
+		}
+
 		SPTableFilterParser *parser = [[SPTableFilterParser alloc] initWithFilterClause:[filter objectForKey:@"Clause"]
 		                                                              numberOfArguments:[[filter objectForKey:@"NumberOfArguments"] integerValue]];
 		[parser setArgument:[values objectOrNilAtIndex:0]];
-		[parser setFirstBetweenArgument:[values objectOrNilAtIndex:0]];
-		[parser setSecondBetweenArgument:[values objectOrNilAtIndex:1]];
+		[parser setFirstBetweenArgument:firstValue];
+		[parser setSecondBetweenArgument:secondValue];
 		[parser setSuppressLeadingTablePlaceholder:[[filter objectForKey:@"SuppressLeadingFieldPlaceholder"] boolValue]];
 		[parser setCaseSensitive:isBINARY];
 		[parser setCurrentField:[in objectForKey:SerFilterExprColumn]];

--- a/Source/SPTableContent.m
+++ b/Source/SPTableContent.m
@@ -175,7 +175,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		tableRowsSelectable = YES;
 		isFirstChangeInView = YES;
 
-		showFilterRuleEditor = NO;
+		showFilterRuleEditor = YES;
 
 		isFiltered = NO;
 		isLimited = NO;


### PR DESCRIPTION
Re-enable the content filtering bar by default when looking at table contents.

The ability to clear the current filter by making the input values empty is probably not the best way to clear a filter - this can be improved upon later.


Ideally we would add a cancel or suspend button (which could also be triggered by pressing escape key in any of the filter values - similar to the behaviour of the last released version), if someone is able point me in the right direction for how to go about hooking that up I will add it.