### PR TITLE
Query favourites one-click-auto-sorting

### DIFF
--- a/Interfaces/English.lproj/QueryFavoriteManager.xib
+++ b/Interfaces/English.lproj/QueryFavoriteManager.xib
@@ -186,6 +186,13 @@ Gw
                                                             <action selector="importFavoritesByAdding:" target="-2" id="369"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="dBw-fd-qFr"/>
+                                                    <menuItem title="Sort Favorites..." toolTip="Sort query favorites alphabetically, A to Z." id="a0m-jn-lJC">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="sortFavoritesAlphabetically:" target="-2" id="DLo-wY-y9c"/>
+                                                        </connections>
+                                                    </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="364"/>
                                                     <menuItem title="Save Query to File..." toolTip="Save query of selected favorite to file" id="365">
                                                         <modifierMask key="keyEquivalentModifierMask"/>

--- a/Source/SPQueryFavoriteManager.h
+++ b/Source/SPQueryFavoriteManager.h
@@ -72,6 +72,7 @@
 - (IBAction)exportFavorites:(id)sender;
 - (IBAction)importFavoritesByAdding:(id)sender;
 - (IBAction)importFavoritesByReplacing:(id)sender;
+- (IBAction)sortFavoritesAlphabetically:(id)sender;
 - (IBAction)closeQueryManagerSheet:(id)sender;
 - (IBAction)insertPlaceholder:(id)sender;
 - (IBAction)showHelp:(id)sender;

--- a/Source/SPQueryFavoriteManager.m
+++ b/Source/SPQueryFavoriteManager.m
@@ -385,11 +385,51 @@
 - (IBAction)sortFavoritesAlphabetically:(id)sender
 {
 #ifndef SP_CODA
-    NSLog(@"%s", "sort pressed");
-    NSLog(@"%@", favorites);
-    
-//    [favoritesArrayController rearrangeObjects];
-//    [favoritesTableView reloadData];
+	NSMutableSet *sortedFavoritesSet;
+	NSMutableArray *sortedFavoritesChunk = [[NSMutableArray alloc] init];
+	NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES];
+	
+	[sortedFavoritesChunk addObject:@{
+		@"name"            : @"Global",
+		@"headerOfFileURL" : @"",
+		@"query"           : @""
+	}];
+	
+	sortedFavoritesSet = [NSMutableSet setWithArray:sortedFavoritesChunk];
+	[sortedFavoritesChunk removeAllObjects];
+	
+	// FIXME: Still sorting fixed file headers
+	
+	if([prefs objectForKey:SPQueryFavorites]) {
+		for(id fav in [prefs objectForKey:SPQueryFavorites])
+			[sortedFavoritesChunk addObject:[[fav mutableCopy] autorelease]];
+	}
+	
+	[sortedFavoritesChunk sortUsingDescriptors:@[sortDescriptor]];
+	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
+	[sortedFavoritesChunk removeAllObjects];
+	
+	[sortedFavoritesChunk addObject:[NSDictionary dictionaryWithObjectsAndKeys:
+						  [[[delegatesFileURL absoluteString] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] lastPathComponent], @"name",
+						  [delegatesFileURL absoluteString], @"headerOfFileURL",
+						  @"", @"query",
+						  nil]];
+	
+	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
+	[sortedFavoritesChunk removeAllObjects];
+	
+	if([[SPQueryController sharedQueryController] favoritesForFileURL:delegatesFileURL]) {
+		for(id fav in [[SPQueryController sharedQueryController] favoritesForFileURL:delegatesFileURL])
+			[sortedFavoritesChunk addObject:[[fav mutableCopy] autorelease]];
+	}
+	
+	[sortedFavoritesChunk sortUsingDescriptors:@[sortDescriptor]];
+	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
+	[sortedFavoritesChunk removeAllObjects];
+	
+	favorites = [[sortedFavoritesSet allObjects] mutableCopy];
+	
+    [favoritesTableView reloadData];
 #endif
 }
 

--- a/Source/SPQueryFavoriteManager.m
+++ b/Source/SPQueryFavoriteManager.m
@@ -380,6 +380,20 @@
 }
 
 /**
+ * Sorts the users favorites alphabetically
+ */
+- (IBAction)sortFavoritesAlphabetically:(id)sender
+{
+#ifndef SP_CODA
+    NSLog(@"%s", "sort pressed");
+    NSLog(@"%@", favorites);
+    
+//    [favoritesArrayController rearrangeObjects];
+//    [favoritesTableView reloadData];
+#endif
+}
+
+/**
  * Insert placeholder - the placeholder string is stored as tooltip
  */
 - (IBAction)insertPlaceholder:(id)sender

--- a/Source/SPQueryFavoriteManager.m
+++ b/Source/SPQueryFavoriteManager.m
@@ -385,20 +385,16 @@
 - (IBAction)sortFavoritesAlphabetically:(id)sender
 {
 #ifndef SP_CODA
-	NSMutableSet *sortedFavoritesSet;
+	[favorites removeAllObjects];
+	
 	NSMutableArray *sortedFavoritesChunk = [[NSMutableArray alloc] init];
 	NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES];
 	
-	[sortedFavoritesChunk addObject:@{
+	[favorites addObject:@{
 		@"name"            : @"Global",
 		@"headerOfFileURL" : @"",
 		@"query"           : @""
 	}];
-	
-	sortedFavoritesSet = [NSMutableSet setWithArray:sortedFavoritesChunk];
-	[sortedFavoritesChunk removeAllObjects];
-	
-	// FIXME: Still sorting fixed file headers
 	
 	if([prefs objectForKey:SPQueryFavorites]) {
 		for(id fav in [prefs objectForKey:SPQueryFavorites])
@@ -406,17 +402,14 @@
 	}
 	
 	[sortedFavoritesChunk sortUsingDescriptors:@[sortDescriptor]];
-	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
+	[favorites addObjectsFromArray:sortedFavoritesChunk];
 	[sortedFavoritesChunk removeAllObjects];
 	
-	[sortedFavoritesChunk addObject:[NSDictionary dictionaryWithObjectsAndKeys:
+	[favorites addObject:[NSDictionary dictionaryWithObjectsAndKeys:
 						  [[[delegatesFileURL absoluteString] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] lastPathComponent], @"name",
 						  [delegatesFileURL absoluteString], @"headerOfFileURL",
 						  @"", @"query",
 						  nil]];
-	
-	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
-	[sortedFavoritesChunk removeAllObjects];
 	
 	if([[SPQueryController sharedQueryController] favoritesForFileURL:delegatesFileURL]) {
 		for(id fav in [[SPQueryController sharedQueryController] favoritesForFileURL:delegatesFileURL])
@@ -424,12 +417,13 @@
 	}
 	
 	[sortedFavoritesChunk sortUsingDescriptors:@[sortDescriptor]];
-	[sortedFavoritesSet addObjectsFromArray:sortedFavoritesChunk];
-	[sortedFavoritesChunk removeAllObjects];
+	[favorites addObjectsFromArray:sortedFavoritesChunk];
 	
-	favorites = [[sortedFavoritesSet allObjects] mutableCopy];
+	[sortedFavoritesChunk release];
+	[sortDescriptor release];
 	
-    [favoritesTableView reloadData];
+	[favoritesArrayController rearrangeObjects];
+	[favoritesTableView reloadData];
 #endif
 }
 


### PR DESCRIPTION
Adds an option to sort query favourites by alphabetically ascending order in one click, which can be found in the query favourites window, underneath the import/export menu options.