### PR TITLE
Fix incorrect layout when window is resized externally

### DIFF
--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -35,6 +35,7 @@
 - (void)_setupTrackingRectsForCell:(PSMTabBarCell *)cell;
 - (void)_positionOverflowMenu;
 - (void)_checkWindowFrame;
+- (void)update:(BOOL)animate updateTabs:(BOOL)updateTabs;
 
     // actions
 - (void)closeTabClick:(id)sender;
@@ -1044,19 +1045,25 @@
 
 - (void)update:(BOOL)animate
 {
+	[self update:animate updateTabs:YES];
+}
+
+- (void)update:(BOOL)animate updateTabs:(BOOL)updateTabs
+{
     // make sure all of our tabs are accounted for before updating,
 	// or only proceed if a drag is in progress (where counts may mismatch)
     if ([[self tabView] numberOfTabViewItems] != (NSInteger)[_cells count] && ![[PSMTabDragAssistant sharedDragAssistant] isDragging]) {
         return;
     }
 
-    // hide/show? (these return if already in desired state)
-    if ( (_hideForSingleTab) && ([_cells count] <= 1) ) {
-        [self hideTabBar:YES animate:YES];
-//        return;
-    } else {
-        [self hideTabBar:NO animate:YES];
-    }
+	if (updateTabs) {
+		// hide/show? (these return if already in desired state)
+		if ( (_hideForSingleTab) && ([_cells count] <= 1) ) {
+			[self hideTabBar:YES animate:YES];
+		} else {
+			[self hideTabBar:NO animate:YES];
+		}
+	}
 	
     [self removeAllToolTips];
     [_controller layoutCells]; //eventually we should only have to call this when we know something has changed
@@ -1691,7 +1698,7 @@
 							   afterDelay:0];
 	}
 
-	[self update:NO];
+	[self update:NO updateTabs:NO];
 }
 
 - (void)viewDidMoveToWindow


### PR DESCRIPTION
Not sure if the title is an accurate description.

This fixes #3091 and doesn't seem to disrupt the normal animations involved in adding/removing/moving tabs.  I think this is good enough for fixing a disruptive workflow bug even though it doesn't address the bug mentioned in https://github.com/sequelpro/sequelpro/issues/3091#issuecomment-398902155.

IMO, a practical approach to the overall problem is to not animate the tab bar's visibility so that the partnerView is updated immediately using current dimensions.