### PR TITLE
Implemented support for specifying a PKCS11 Provider in .plist

### DIFF
--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -189,6 +189,8 @@
 	<false/>
 	<key>TableInformationPanelCollapsed</key>
 	<false/>
+	<key>SSHClientPKCS11Provider</key>
+	<string>/usr/local/lib/scd-pkcs11.so</string>
 	<key>TableRowCountCheapLookupSizeBoundary</key>
 	<integer>5242880</integer>
 	<key>TableRowCountQueryLevel</key>

--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -451,6 +451,7 @@ extern NSString *SPSelectionDetailTypeIndexed;
 extern NSString *SPSelectionDetailTypePrimaryKeyed;
 extern NSString *SPSSHEnableMuxingPreference;
 extern NSString *SPSSHClientPath;
+extern NSString *SPSSHPKCS11Provider;
 extern NSString *SPSSLCipherListKey;
 extern NSString *SPQueryFavoritesHaveBeenUpdatedNotification;
 extern NSString *SPHistoryItemsHaveBeenUpdatedNotification;

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -236,6 +236,7 @@ NSString *SPSelectionDetailTypeIndexed           = @"SelectionDetailTypeNSIndexS
 NSString *SPSelectionDetailTypePrimaryKeyed      = @"SelectionDetailTypePrimaryKeyedDetails";
 NSString *SPSSHEnableMuxingPreference            = @"SSHMultiplexingEnabled";
 NSString *SPSSHClientPath                        = @"SSHClientPath";
+NSString *SPSSHPKCS11Provider                    = @"SSHClientPKCS11Provider";
 NSString *SPSSLCipherListKey                     = @"SSLCipherList";
 NSString *SPQueryFavoritesHaveBeenUpdatedNotification = @"QueryFavoritesHaveBeenUpdatedNotification";
 NSString *SPHistoryItemsHaveBeenUpdatedNotification   = @"HistoryItemsHaveBeenUpdatedNotification";

--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -328,7 +328,11 @@ static unsigned short getRandomPort();
 
 		// Ensure that the connection can be used for only tunnels, not interactive
 		[taskArguments addObject:@"-N"];
-
+		
+		NSString *pkcs11Provider = [[NSUserDefaults standardUserDefaults] stringForKey:SPSSHPKCS11Provider];
+		if (pkcs11Provider) {
+			[taskArguments addObject:[NSString stringWithFormat:@"-I %@",pkcs11Provider]];
+		}
 		// If explicitly enabled, activate connection multiplexing - note that this can cause connection
 		// instability on some setups, so is currently disabled by default.
 		if (connectionMuxingEnabled) {


### PR DESCRIPTION
Added support for specifying a PKCS11 provider using the info.plist. Tested on MacOS.