### PR TITLE
Toolbar position fix

### DIFF
--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -5895,7 +5895,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	CGFloat leftPaneWidth = [[[contentViewSplitter subviews] objectAtIndex:0] frame].size.width;
 
 	// subtract some pixels to allow for misc stuff
-	leftPaneWidth -= 12;
+	leftPaneWidth -= 9;
 
 	// make sure it's not too small or to big
 	if (leftPaneWidth < 130) leftPaneWidth = 130;


### PR DESCRIPTION
Toolbar items are slightly shifted, making an undesirable "cross" in the UI:
![screen shot 2019-02-15 at 1 39 11 am](https://user-images.githubusercontent.com/1531639/52825224-913e1900-30c4-11e9-8a92-4a12131dba91.png)

This fix is intended to resolve that:
![screen shot 2019-02-15 at 1 52 11 am](https://user-images.githubusercontent.com/1531639/52825233-9602cd00-30c4-11e9-9918-bbab769cf5da.png)
