### PR TITLE
Update clientid to use latest version of dpriver sql formater

### DIFF
--- a/SharedSupport/Default Bundles/Format SQL.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Format SQL.spBundle/command.plist
@@ -155,7 +155,7 @@ cat &lt;&lt;HTML
 						&lt;input type="checkbox" name="compactmode" value="yes"&gt; Compact the output of sql output
 						&lt;input type="text" name="maxlenincm" value= "80" size = 5 &gt; 
 					&lt;/div&gt;
-					&lt;input type="hidden" name="clientid" value="4149-9094-8133-2031" /&gt; 
+					&lt;input type="hidden" name="clientid" value="dpriver-9094-8133-2031" /&gt; 
 				&lt;/form&gt;
 			&lt;/div&gt;
 		&lt;/div&gt;


### PR DESCRIPTION
SQL Format action is showing an error message "refresh to update to latest version"
Changing client id in the form fix this issue.