### PR TITLE
Allow escape to close the SSH password dialog

### DIFF
--- a/Interfaces/English.lproj/SSHQuestionDialog.xib
+++ b/Interfaces/English.lproj/SSHQuestionDialog.xib
@@ -123,8 +123,9 @@ DQ
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="479">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
-                            <string key="keyEquivalent">.</string>
-                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
                         </buttonCell>
                         <connections>
                             <action selector="closeSSHPasswordSheet:" target="-2" id="495"/>


### PR DESCRIPTION
This pull request enables the use of the escape key to dismiss the SSH password dialog. This is achieved by changing the key equivalent from `⌘.` to `⎋`. Changing this behaviour results in both `⎋` and `⌘.` closing the dialog.